### PR TITLE
Fix ImplicitSurfaceAdaptiveConstraint compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,26 @@ jobs:
           name: BeamAdapter_${{ steps.sofa.outputs.run_branch }}_for-SOFA-${{ steps.sofa.outputs.sofa_version }}_${{ runner.os }}
           path: ${{ env.WORKSPACE_ARTIFACT_PATH }}
       
+      - name: Set env vars for tests
+        shell: bash
+        run: |
+          # Set env vars for tests
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "$WORKSPACE_ARTIFACT_PATH/lib" >> $GITHUB_PATH
+            echo "$WORKSPACE_ARTIFACT_PATH/bin" >> $GITHUB_PATH
+          else
+            # need to add the new lib dir for SOFA to load with PluginManager (no need on Windows, it will find it from PATH)
+            echo "SOFA_PLUGIN_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$SOFA_PLUGIN_PATH" | tee -a $GITHUB_ENV
+          fi
+
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            echo "DYLD_LIBRARY_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$SOFA_ROOT/lib:$DYLD_LIBRARY_PATH" | tee -a $GITHUB_ENV
+          fi
+
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            echo "LD_LIBRARY_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$SOFA_ROOT/lib:$LD_LIBRARY_PATH" | tee -a $GITHUB_ENV
+          fi
+
       #- name: Check environment for tests
       #  shell: bash
       #  run: |

--- a/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.h
+++ b/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.h
@@ -60,22 +60,6 @@ namespace constraint
 namespace _implicitsurfaceadaptiveconstraint_
 {
 
-using namespace sofa::defaulttype;
-using sofa::core::ConstVecCoordId;
-using core::behavior::ConstraintResolution;
-using sofa::component::fem::WireBeamInterpolation;
-using sofa::type::vector;
-using sofa::core::behavior::MechanicalState;
-using type::Vec3d;
-using sofa::linearalgebra::BaseVector;
-using sofa::component::container::ImplicitSurfaceContainer;
-using sofa::core::behavior::PairInteractionConstraint;
-using core::behavior::BaseMechanicalState;
-using core::visual::VisualParams;
-using sofa::core::ConstraintParams;
-using sofa::linearalgebra::BaseVector ;
-
-
 /*!
  * \class ImplicitSurfaceAdaptiveConstraintResolution
  * \brief ImplicitSurfaceAdaptiveConstraintResolution Class
@@ -84,7 +68,7 @@ template<class DataTypes>
 class ImplicitSurfaceAdaptiveConstraintResolution : public sofa::core::behavior::ConstraintResolution
 {
 public:
-    ImplicitSurfaceAdaptiveConstraintResolution(double frictionCoef, int line, WireBeamInterpolation<DataTypes>* wireInterpol)
+    ImplicitSurfaceAdaptiveConstraintResolution(double frictionCoef, int line, sofa::component::fem::WireBeamInterpolation<DataTypes>* wireInterpol)
         : ConstraintResolution(3)
         , m_wireInterpolation(wireInterpol)
         , m_mu(frictionCoef)
@@ -95,7 +79,7 @@ public:
     virtual void resolution(int line, double** w, double* d, double* force);
 
 private:
-    WireBeamInterpolation<DataTypes>* m_wireInterpolation;
+    sofa::component::fem::WireBeamInterpolation<DataTypes>* m_wireInterpolation;
     double m_mu;
     int m_line;
 };
@@ -106,10 +90,10 @@ private:
  * \brief ImplicitSurfaceAdaptiveConstraint Class
  */
 template<class DataTypes>
-class ImplicitSurfaceAdaptiveConstraint : public PairInteractionConstraint<DataTypes>
+class ImplicitSurfaceAdaptiveConstraint : public sofa::core::behavior::PairInteractionConstraint<DataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(ImplicitSurfaceAdaptiveConstraint,DataTypes),SOFA_TEMPLATE(PairInteractionConstraint,DataTypes));
+    SOFA_CLASS(SOFA_TEMPLATE(ImplicitSurfaceAdaptiveConstraint,DataTypes),SOFA_TEMPLATE(sofa::core::behavior::PairInteractionConstraint,DataTypes));
 
     typedef typename core::behavior::PairInteractionConstraint<DataTypes> Inherit;
 
@@ -125,15 +109,15 @@ public:
     typedef type::Vec<3,Real> Vec3;
     typedef type::Vec<3,double> Vec3d;
     typedef typename core::behavior::MechanicalState<DataTypes> MechanicalState;
-    typedef WireBeamInterpolation<DataTypes> WBInterpolation;
+    typedef typename component::fem::WireBeamInterpolation<DataTypes> WBInterpolation;
 
     typedef Data<VecCoord>		 DataVecCoord;
     typedef Data<VecDeriv>		 DataVecDeriv;
     typedef Data<MatrixDeriv>    DataMatrixDeriv;
 
-    typedef typename SolidTypes<Real>::Transform Transform;
-    typedef typename SolidTypes<Real>::SpatialVector SpatialVector;
-    typedef typename vector<int>::iterator VectorIntIterator;
+    typedef typename defaulttype::SolidTypes<Real>::Transform Transform;
+    typedef typename defaulttype::SolidTypes<Real>::SpatialVector SpatialVector;
+    typedef typename type::vector<int>::iterator VectorIntIterator;
 
 protected :
     SingleLink<ImplicitSurfaceAdaptiveConstraint<DataTypes>, WBInterpolation, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_wireBinterpolation;
@@ -145,7 +129,7 @@ protected :
     Data<Real>  d_alarmDistance;
     Data<Real>  d_radius;
     Data<Real>  d_frictionCoef;
-    Data<vector<int> > d_listBeams;
+    Data<type::vector<int> > d_listBeams;
 
 #ifdef SOFAEVE
     sofaeve::implicit::MarchingCube * mc;
@@ -154,10 +138,10 @@ protected :
     unsigned int m_cid;
     double m_cData[100000000];
     Real m_isoValue;
-    vector<bool> m_activeList;
+    type::vector<bool> m_activeList;
     bool m_friction;
     bool m_allActivated; /// list of beams to be considered for collision
-    ImplicitSurfaceContainer* m_contactSurface;
+    component::container::ImplicitSurfaceContainer* m_contactSurface;
     int m_nbConstraints;
     bool isHolonomic() {return false;} /// this constraint is NOT holonomic
 
@@ -169,8 +153,8 @@ public:
 
     ~ImplicitSurfaceAdaptiveConstraint(){}
 
-    BaseMechanicalState* getMechModel1() { return this->mstate1; }
-    BaseMechanicalState* getMechModel2() { return this->mstate2; }
+    core::behavior::BaseMechanicalState* getMechModel1() { return this->mstate1; }
+    core::behavior::BaseMechanicalState* getMechModel2() { return this->mstate2; }
 
     void init();
     void clear();
@@ -179,22 +163,22 @@ public:
     void reset();
     void reinit(){internalInit();}
 
-    void buildConstraintMatrix(const ConstraintParams* cParams,
+    void buildConstraintMatrix(const core::ConstraintParams* cParams,
                                DataMatrixDeriv &c1, DataMatrixDeriv &c2, unsigned int &cIndex,
                                const DataVecCoord &, const DataVecCoord &x2) ;
 
-    void getConstraintViolation(const ConstraintParams* cParams, BaseVector *v,
+    void getConstraintViolation(const core::ConstraintParams* cParams, linearalgebra::BaseVector *v,
                                 const DataVecCoord &x1, const DataVecCoord &x2,
                                 const DataVecDeriv &v1, const DataVecDeriv &v2) ;
 
-    void getConstraintResolution(std::vector<ConstraintResolution*>& resTab, unsigned int& offset);
+    void getConstraintResolution(std::vector<core::behavior::ConstraintResolution*>& resTab, unsigned int& offset);
 
-    void draw(const VisualParams* vparams);
+    void draw(const core::visual::VisualParams* vparams);
 
 
 private:
-    vector<Vec3> m_posSample;
-    vector<int> m_domainSample;
+    type::vector<Vec3> m_posSample;
+    type::vector<int> m_domainSample;
 
     struct potentialContact{
         unsigned int beamId;
@@ -204,16 +188,16 @@ private:
         Real d;
     };
 
-    vector<potentialContact> m_vecPotentialContact;
+    type::vector<potentialContact> m_vecPotentialContact;
 
     void getOrthogonalVectors(const Vec3& dir, Vec3& vec1, Vec3& vec2);
-    void detectPotentialContactOnImplicitSurface(const ConstVecCoordId &vecXId, vector<int>& listBeam);
+    void detectPotentialContactOnImplicitSurface(const core::ConstVecCoordId &vecXId, type::vector<int>&listBeam);
     void computeTangentialViolation(const Vec3 &Pos, const Vec3 &freePos, const Vec3 &t, const Vec3 &s,
                                     const Real& d, const Real& dfree, Real &dfree_t, Real &dfree_s );
 
 
-    using PairInteractionConstraint<DataTypes>::mstate1;
-    using PairInteractionConstraint<DataTypes>::mstate2;
+    using core::behavior::PairInteractionConstraint<DataTypes>::mstate1;
+    using core::behavior::PairInteractionConstraint<DataTypes>::mstate2;
 
 };
 

--- a/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.inl
+++ b/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.inl
@@ -216,7 +216,7 @@ void ImplicitSurfaceAdaptiveConstraint<DataTypes>::getOrthogonalVectors(const Ve
 /// "filters" contacts (the normal of contact is supposed to be perp to the tangent of the curve except on the tip point)
 /// set  normal and tangential directions
 template<class DataTypes>
-void ImplicitSurfaceAdaptiveConstraint<DataTypes>::detectPotentialContactOnImplicitSurface(const ConstVecCoordId &vecXId, vector<int>& listBeam)
+void ImplicitSurfaceAdaptiveConstraint<DataTypes>::detectPotentialContactOnImplicitSurface(const ConstVecCoordId &vecXId, type::vector<int>& listBeam)
 {
     unsigned int numBeams= l_wireBinterpolation->getNumBeams();
 
@@ -312,7 +312,7 @@ void ImplicitSurfaceAdaptiveConstraint<DataTypes>::detectPotentialContactOnImpli
 }
 
 template<class DataTypes>
-void ImplicitSurfaceAdaptiveConstraint<DataTypes>::buildConstraintMatrix(const ConstraintParams* cParams,
+void ImplicitSurfaceAdaptiveConstraint<DataTypes>::buildConstraintMatrix(const core::ConstraintParams* cParams,
                                                                          DataMatrixDeriv &c1,
                                                                          DataMatrixDeriv &c2,
                                                                          unsigned int &cIndex,
@@ -541,8 +541,8 @@ void ImplicitSurfaceAdaptiveConstraint<DataTypes>::computeTangentialViolation(co
 
 
 template<class DataTypes>
-void ImplicitSurfaceAdaptiveConstraint<DataTypes>::getConstraintViolation(const ConstraintParams* cParams,
-                                                                          BaseVector *v,
+void ImplicitSurfaceAdaptiveConstraint<DataTypes>::getConstraintViolation(const core::ConstraintParams* cParams,
+                                                                          linearalgebra::BaseVector *v,
                                                                           const DataVecCoord &x1,
                                                                           const DataVecCoord &x2,
                                                                           const DataVecDeriv &v1,
@@ -602,7 +602,7 @@ void ImplicitSurfaceAdaptiveConstraint<DataTypes>::getConstraintViolation(const 
 
 
 template<class DataTypes>
-void ImplicitSurfaceAdaptiveConstraint<DataTypes>::getConstraintResolution(std::vector<ConstraintResolution*>& resTab, unsigned int& offset)
+void ImplicitSurfaceAdaptiveConstraint<DataTypes>::getConstraintResolution(std::vector<core::behavior::ConstraintResolution* > & resTab, unsigned int& offset)
 {
 
 #ifdef DEBUG
@@ -629,7 +629,7 @@ void ImplicitSurfaceAdaptiveConstraint<DataTypes>::getConstraintResolution(std::
 }
 
 template<class DataTypes>
-void ImplicitSurfaceAdaptiveConstraint<DataTypes>::draw(const VisualParams* vparams)
+void ImplicitSurfaceAdaptiveConstraint<DataTypes>::draw(const core::visual::VisualParams* vparams)
 {
 #ifdef DEBUG
     dmsg_info()<<" entering draw";

--- a/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.inl
+++ b/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.inl
@@ -120,7 +120,7 @@ ImplicitSurfaceAdaptiveConstraint<DataTypes>::ImplicitSurfaceAdaptiveConstraint(
 template<class DataTypes>
 void ImplicitSurfaceAdaptiveConstraint<DataTypes>::init()
 {
-    PairInteractionConstraint<DataTypes>::init();
+    Inherit::init();
 }
 
 
@@ -173,7 +173,7 @@ void ImplicitSurfaceAdaptiveConstraint<DataTypes>::internalInit()
 
 
     // STEP 4: verify if listBeams is void => all beams are activated
-    const vector<int> &list_B= d_listBeams.getValue();
+    const type::vector<int> &list_B= d_listBeams.getValue();
     if( list_B.size() == 0)
         m_allActivated=true;
     else
@@ -328,7 +328,7 @@ void ImplicitSurfaceAdaptiveConstraint<DataTypes>::buildConstraintMatrix(const c
 
     //1st step: computation of sample point position (10 / beam)
     // if all activated => all beam considered otherwize, use listBeams...
-    vector<int> list_B;
+    type::vector<int> list_B;
     unsigned int numBeams= l_wireBinterpolation->getNumBeams();
     m_allActivated=false;
     if (m_allActivated)

--- a/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.inl
+++ b/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.inl
@@ -356,8 +356,9 @@ void ImplicitSurfaceAdaptiveConstraint<DataTypes>::buildConstraintMatrix(const c
     // the following code verify that the position is correct:
     dmsg_info() <<" in buildConstraintMatrix: cParams->x()="<<cParams->x();
 
-    MultiVecCoordId x = VecCoordId::position();
-    ConstVecCoordId xtest = cParams->readX(this->mstate2);
+    MultiVecCoordId x = VecCoordId::position(); 
+    ConstVecCoordId xtest = cParams->x()[this->mstate2.get()];
+    //ConstVecCoordId xtest = cParams->readX(this->mstate2);
 
     if(xtest != x.getId(this->mstate2))
     {
@@ -368,7 +369,7 @@ void ImplicitSurfaceAdaptiveConstraint<DataTypes>::buildConstraintMatrix(const c
     const VecCoord &x2buf = x2.getValue();
     sofa::core::VecCoordId x_in = sofa::core::VecCoordId::position();
 
-    const VecCoord &x2test=*this->mstate2->getX();
+    auto x2test = sofa::helper::getReadAccessor(*(this->mstate2->read(core::ConstVecCoordId::position())));
     l_wireBinterpolation->updateBezierPoints(x2test, x_in );
 
     // interpolates the position of the sample points


### PR DESCRIPTION
Using "using namespace" in header is bad, m'kay....

And this component is even not usable by the way 😵 (because of not SOFAEVE)
but the instantiation itself could not even compile as well (use of deprecated/deleted functions)