### PR TITLE
[src] Fix AdvancedTimer logs

### DIFF
--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
@@ -691,8 +691,6 @@ template<class DataTypes>
 void AdaptiveBeamForceFieldAndMass<DataTypes>::addDForce(const MechanicalParams* mparams,
                                                          DataVecDeriv& datadF, const DataVecDeriv& datadX )
 {
-    ScopedAdvancedTimer timer("AdaptiveBeamForceFieldAndMass_addDForce");
-
     VecDeriv& df = *datadF.beginEdit();
     const VecDeriv& dx = datadX.getValue();
     const double kFactor = mparams->kFactor();

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
@@ -49,7 +49,7 @@
 #include <sofa/simulation/Simulation.h>
 #include <sofa/gl/Axis.h>
 #include <sofa/core/visual/VisualParams.h>
-
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 
 
@@ -73,6 +73,7 @@ using sofa::type::Quat ;
 using sofa::helper::ReadAccessor ;
 using sofa::core::ConstVecCoordId ;
 using std::set ;
+using sofa::helper::ScopedAdvancedTimer;
 
 template <class DataTypes>
 AdaptiveBeamForceFieldAndMass<DataTypes>::AdaptiveBeamForceFieldAndMass()
@@ -525,6 +526,7 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::addForce (const MechanicalParams*
                                                          const DataVecCoord& datax,
                                                          const DataVecDeriv& v)
 {
+    ScopedAdvancedTimer timer("AdaptiveBeamForceFieldAndMass_addForce");
     SOFA_UNUSED(v);
 
     VecDeriv& f = *dataf.beginEdit() ;
@@ -689,6 +691,8 @@ template<class DataTypes>
 void AdaptiveBeamForceFieldAndMass<DataTypes>::addDForce(const MechanicalParams* mparams,
                                                          DataVecDeriv& datadF, const DataVecDeriv& datadX )
 {
+    ScopedAdvancedTimer timer("AdaptiveBeamForceFieldAndMass_addDForce");
+
     VecDeriv& df = *datadF.beginEdit();
     const VecDeriv& dx = datadX.getValue();
     const double kFactor = mparams->kFactor();

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -192,7 +192,7 @@ void AdaptiveBeamMapping< TIn, TOut>::clear(int size)
 template <class TIn, class TOut>
 void AdaptiveBeamMapping< TIn, TOut>::apply(const MechanicalParams* mparams, Data<VecCoord>& dOut, const Data<InVecCoord>& dIn)
 {
-    AdvancedTimer::stepBegin("AdaptiveBeamMappingApply");
+    AdvancedTimer::stepBegin("AdaptiveBeamMapping_Apply");
     VecCoord& out = *dOut.beginEdit();
     const InVecCoord& in = dIn.getValue();
 
@@ -248,7 +248,7 @@ void AdaptiveBeamMapping< TIn, TOut>::apply(const MechanicalParams* mparams, Dat
     AdvancedTimer::stepEnd("computeNewInterpolation");
 
     dOut.endEdit();
-    AdvancedTimer::stepEnd("AdaptiveBeamMappingApply");
+    AdvancedTimer::stepEnd("AdaptiveBeamMapping_Apply");
 }
 
 
@@ -257,7 +257,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJ(const core::MechanicalParams* mpara
 {
     SOFA_UNUSED(mparams);
 
-    AdvancedTimer::stepBegin("AdaptiveBeamMappingApplyJ");
+    AdvancedTimer::stepBegin("AdaptiveBeamMapping_applyJ");
     VecDeriv& out = *dOut.beginEdit();
     const InVecDeriv& in= dIn.getValue();
     Data<InVecCoord>& dataInX = *this->getFromModel()->write(VecCoordId::position());
@@ -307,7 +307,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJ(const core::MechanicalParams* mpara
 
     dOut.endEdit();
     dataInX.endEdit();
-    AdvancedTimer::stepEnd("AdaptiveBeamMappingApplyJ");
+    AdvancedTimer::stepEnd("AdaptiveBeamMapping_applyJ");
 }
 
 
@@ -316,7 +316,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJT(const core::MechanicalParams* mpar
 {
     SOFA_UNUSED(mparams);
 
-    AdvancedTimer::stepBegin("AdaptiveBeamMappingMechanicalApplyJT");
+    AdvancedTimer::stepBegin("AdaptiveBeamMapping_applyJT");
     InVecDeriv& out = *dOut.beginEdit();
     const VecDeriv& in= dIn.getValue();
 
@@ -348,7 +348,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJT(const core::MechanicalParams* mpar
     }
 
     dOut.endEdit();
-    AdvancedTimer::stepEnd("AdaptiveBeamMappingMechanicalApplyJT");
+    AdvancedTimer::stepEnd("AdaptiveBeamMapping_applyJT");
 }
 
 
@@ -362,8 +362,8 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJT(const core::ConstraintParams* cpar
 {
     SOFA_UNUSED(cparams);
 
-    AdvancedTimer::stepBegin("AdaptiveBeamMappingConstrainApplyJT");
-
+    AdvancedTimer::stepBegin("AdaptiveBeamMapping_ApplyJT");
+    
     InMatrixDeriv& out = *dOut.beginEdit();
     const OutMatrixDeriv& in = dIn.getValue();
     const Data<InVecCoord>& dataInX = *this->getFromModel()->read(ConstVecCoordId::position());
@@ -433,7 +433,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJT(const core::ConstraintParams* cpar
     }
 
     dOut.endEdit();
-    AdvancedTimer::stepEnd("AdaptiveBeamMappingConstraintApplyJT");
+    AdvancedTimer::stepEnd("AdaptiveBeamMapping_ApplyJT");
 }
 
 template <class TIn, class TOut>

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -42,6 +42,7 @@
 
 #include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 #include <sofa/core/ConstraintParams.h>
 #include <sofa/core/MechanicalParams.h>
 
@@ -63,6 +64,7 @@ using helper::ReadAccessor;
 using helper::WriteAccessor;
 using sofa::core::ConstVecCoordId;
 using sofa::helper::AdvancedTimer;
+using sofa::helper::ScopedAdvancedTimer;
 using sofa::core::MultiVecCoordId;
 using sofa::core::VecCoordId;
 using sofa::core::ConstMultiVecCoordId;
@@ -192,7 +194,7 @@ void AdaptiveBeamMapping< TIn, TOut>::clear(int size)
 template <class TIn, class TOut>
 void AdaptiveBeamMapping< TIn, TOut>::apply(const MechanicalParams* mparams, Data<VecCoord>& dOut, const Data<InVecCoord>& dIn)
 {
-    AdvancedTimer::stepBegin("AdaptiveBeamMapping_Apply");
+    ScopedAdvancedTimer timer("AdaptiveBeamMapping_Apply");
     VecCoord& out = *dOut.beginEdit();
     const InVecCoord& in = dIn.getValue();
 
@@ -248,7 +250,6 @@ void AdaptiveBeamMapping< TIn, TOut>::apply(const MechanicalParams* mparams, Dat
     AdvancedTimer::stepEnd("computeNewInterpolation");
 
     dOut.endEdit();
-    AdvancedTimer::stepEnd("AdaptiveBeamMapping_Apply");
 }
 
 
@@ -256,8 +257,8 @@ template <class TIn, class TOut>
 void AdaptiveBeamMapping< TIn, TOut>::applyJ(const core::MechanicalParams* mparams, Data<VecDeriv>& dOut, const Data<InVecDeriv>& dIn)
 {
     SOFA_UNUSED(mparams);
+    ScopedAdvancedTimer timer("AdaptiveBeamMapping_applyJ");
 
-    AdvancedTimer::stepBegin("AdaptiveBeamMapping_applyJ");
     VecDeriv& out = *dOut.beginEdit();
     const InVecDeriv& in= dIn.getValue();
     Data<InVecCoord>& dataInX = *this->getFromModel()->write(VecCoordId::position());
@@ -307,7 +308,6 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJ(const core::MechanicalParams* mpara
 
     dOut.endEdit();
     dataInX.endEdit();
-    AdvancedTimer::stepEnd("AdaptiveBeamMapping_applyJ");
 }
 
 
@@ -316,7 +316,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJT(const core::MechanicalParams* mpar
 {
     SOFA_UNUSED(mparams);
 
-    AdvancedTimer::stepBegin("AdaptiveBeamMapping_applyJT");
+    ScopedAdvancedTimer timer("AdaptiveBeamMapping_applyJT");
     InVecDeriv& out = *dOut.beginEdit();
     const VecDeriv& in= dIn.getValue();
 
@@ -348,7 +348,6 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJT(const core::MechanicalParams* mpar
     }
 
     dOut.endEdit();
-    AdvancedTimer::stepEnd("AdaptiveBeamMapping_applyJT");
 }
 
 
@@ -362,7 +361,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJT(const core::ConstraintParams* cpar
 {
     SOFA_UNUSED(cparams);
 
-    AdvancedTimer::stepBegin("AdaptiveBeamMapping_ApplyJT");
+    ScopedAdvancedTimer timer("AdaptiveBeamMapping_ApplyJT");
     
     InMatrixDeriv& out = *dOut.beginEdit();
     const OutMatrixDeriv& in = dIn.getValue();
@@ -433,7 +432,6 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJT(const core::ConstraintParams* cpar
     }
 
     dOut.endEdit();
-    AdvancedTimer::stepEnd("AdaptiveBeamMapping_ApplyJT");
 }
 
 template <class TIn, class TOut>

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
@@ -37,6 +37,7 @@
 
 #include <sofa/simulation/AnimateBeginEvent.h>
 #include <sofa/core/MechanicalParams.h>
+#include <sofa/helper/ScopedAdvancedTimer.h>
 
 
 namespace sofa
@@ -49,7 +50,7 @@ namespace mapping
 {
 
 using namespace sofa::defaulttype;
-
+using sofa::helper::ScopedAdvancedTimer;
 
 
 template <class TIn, class TOut>
@@ -79,6 +80,8 @@ MultiAdaptiveBeamMapping< TIn, TOut>::MultiAdaptiveBeamMapping()
 template <class TIn, class TOut>
 void MultiAdaptiveBeamMapping< TIn, TOut>::apply(const core::MechanicalParams* mparams /* PARAMS FIRST */, Data<VecCoord>& dOut, const Data<InVecCoord>& dIn)
 {
+    ScopedAdvancedTimer timer("MultiAdaptiveBeamMapping_apply");
+
     VecCoord& out = *dOut.beginEdit();
     if(!isBarycentricMapping)
         out.resize(_xPointList.size());
@@ -99,6 +102,8 @@ void MultiAdaptiveBeamMapping< TIn, TOut>::apply(const core::MechanicalParams* m
 template <class TIn, class TOut>
 void MultiAdaptiveBeamMapping< TIn, TOut>::applyJ(const core::MechanicalParams* mparams /* PARAMS FIRST */, Data<VecDeriv>& dOut, const Data<InVecDeriv>& dIn)
 {
+    ScopedAdvancedTimer timer("MultiAdaptiveBeamMapping_applyJ");
+
     for (unsigned int subMap=0; subMap<m_subMappingList.size(); subMap++)
     {
         if (this->f_printLog.getValue()){
@@ -111,6 +116,8 @@ void MultiAdaptiveBeamMapping< TIn, TOut>::applyJ(const core::MechanicalParams* 
 template <class TIn, class TOut>
 void MultiAdaptiveBeamMapping< TIn, TOut>::applyJT(const core::MechanicalParams* mparams /* PARAMS FIRST */, Data<InVecDeriv>& dOut, const Data<VecDeriv>& dIn)
 {
+    ScopedAdvancedTimer timer("MultiAdaptiveBeamMapping_applyJT");
+
     for (unsigned int subMap=0; subMap<m_subMappingList.size(); subMap++)
     {
         if (this->f_printLog.getValue()){
@@ -130,6 +137,8 @@ void MultiAdaptiveBeamMapping< TIn, TOut>::applyJT(const core::MechanicalParams*
 template <class TIn, class TOut>
 void MultiAdaptiveBeamMapping< TIn, TOut>::applyJT(const core::ConstraintParams* cparams /* PARAMS FIRST */, Data<InMatrixDeriv>& dOut, const Data<OutMatrixDeriv>& dIn)
 {
+    ScopedAdvancedTimer timer("MultiAdaptiveBeamMapping_applyJT");
+
     for (unsigned int subMap=0; subMap<m_subMappingList.size(); subMap++)
     {
         if (this->f_printLog.getValue()){


### PR DESCRIPTION
Some `AdvancedTimer` stepBegin/stepEnd had spelling inconsistencies 