### PR TITLE
Fix: remove compat topology file from WireRestShape

### DIFF
--- a/src/BeamAdapter/component/engine/WireRestShape.inl
+++ b/src/BeamAdapter/component/engine/WireRestShape.inl
@@ -35,9 +35,9 @@
 #include <cmath>
 
 #include <sofa/core/behavior/MechanicalState.h>
-#include <SofaBaseTopology/QuadSetTopologyModifier.h>
-#include <SofaBaseTopology/EdgeSetGeometryAlgorithms.h>
-#include <SofaTopologyMapping/Edge2QuadTopologicalMapping.h>
+#include <sofa/component/topology/container/dynamic/QuadSetTopologyModifier.h>
+#include <sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.h>
+#include <sofa/component/topology/mapping/Edge2QuadTopologicalMapping.h>
 
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/TopologyChangeVisitor.h>
@@ -325,7 +325,7 @@ void WireRestShape<DataTypes>::releaseWirePart(){
             if(edge2QuadMap!=NULL)
             {
                 edge2QuadMap->updateTopologicalMappingTopDown();
-                sofa::component::topology::QuadSetTopologyModifier *quadMod;
+                sofa::component::topology::container::dynamic::QuadSetTopologyModifier *quadMod;
                 edge2QuadMap->getContext()->get(quadMod);
                 quadMod->notifyEndingEvent();
             }


### PR DESCRIPTION
This change has been lost during rebase of #21 