### PR TITLE
Compile ImplicitSurfaceAdaptiveConstraint with nocompat

### DIFF
--- a/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.cpp
+++ b/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.cpp
@@ -19,18 +19,12 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#include "ImplicitSurfaceAdaptiveConstraint.inl"
+#include <BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.inl>
 
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/ObjectFactory.h>
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace constraint
+namespace sofa::component::constraint
 {
 
 using namespace sofa::defaulttype;
@@ -44,15 +38,8 @@ SOFA_DECL_CLASS(ImplicitSurfaceAdaptiveConstraint)
 int ImplicitSurfaceAdaptiveConstraintClass = RegisterObject("PROUT TODO-ImplicitSurfaceAdaptiveConstraint")
 .add< ImplicitSurfaceAdaptiveConstraint<Rigid3Types> >(true)
 
-;
-
 template class ImplicitSurfaceAdaptiveConstraint<Rigid3Types>;
-
 
 #endif  // SOFAEVE
 
-} // namespace constraint
-
-} // namespace component
-
-} // namespace sofa
+} // namespace sofa::component::constraint

--- a/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.cpp
+++ b/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.cpp
@@ -22,7 +22,6 @@
 #include "ImplicitSurfaceAdaptiveConstraint.inl"
 
 #include <sofa/defaulttype/VecTypes.h>
-#include <SofaBaseMechanics/MechanicalObject.h>
 #include <sofa/core/ObjectFactory.h>
 
 namespace sofa

--- a/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.h
+++ b/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.h
@@ -19,15 +19,10 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_COMPONENT_CONSTRAINT_IMPLICITSURFACEADAPTIVECONSTRAINT_H
-#define SOFA_COMPONENT_CONSTRAINT_IMPLICITSURFACEADAPTIVECONSTRAINT_H
-
 #include <sofa/core/behavior/BaseInteractionConstraint.h>
 #include <sofa/core/behavior/PairInteractionConstraint.h>
 #include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/core/visual/VisualModel.h>
 #include <sofa/gl/template.h>
-#include <iostream>
 
 #include <sofa/type/Mat.h>
 #include <sofa/type/Vec.h>
@@ -38,7 +33,7 @@
 
 #include <SofaImplicitField/deprecated/ImplicitSurfaceContainer.h>
 
-#include "../WireBeamInterpolation.h"
+#include <BeamAdapter/component/WireBeamInterpolation.h>
 
 //#define SOFAEVE  //temporary fix for compilation, this component does not work without SOFAEVE (which is however not accessible easily)
 
@@ -47,13 +42,7 @@
 #endif
 
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace constraint
+namespace sofa::component::constraint
 {
 
 namespace _implicitsurfaceadaptiveconstraint_
@@ -150,7 +139,7 @@ public:
     ImplicitSurfaceAdaptiveConstraint(MechanicalState* object);
     ImplicitSurfaceAdaptiveConstraint();
 
-    ~ImplicitSurfaceAdaptiveConstraint(){}
+    virtual ~ImplicitSurfaceAdaptiveConstraint() override = default;
 
     core::behavior::BaseMechanicalState* getMechModel1() { return this->mstate1; }
     core::behavior::BaseMechanicalState* getMechModel2() { return this->mstate2; }
@@ -200,15 +189,9 @@ private:
 
 };
 
-}
+} // namespace _implicitsurfaceadaptiveconstraint_
 
 using _implicitsurfaceadaptiveconstraint_::ImplicitSurfaceAdaptiveConstraint;
 using _implicitsurfaceadaptiveconstraint_::ImplicitSurfaceAdaptiveConstraintResolution;
 
-} // namespace constraint
-
-} // namespace component
-
-} // namespace sofa
-
-#endif // SOFA_COMPONENT_CONSTRAINT_BILATERALINTERACTIONCONSTRAINT_H
+} // namespace sofa::component::constraint

--- a/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.inl
+++ b/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.inl
@@ -25,16 +25,12 @@
 
 #include "ImplicitSurfaceAdaptiveConstraint.h"
 
+#include <sofa/helper/system/thread/CTime.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
-#include <SofaBaseMechanics/AddMToMatrixFunctor.h>
-
-#include <sofa/helper/system/thread/CTime.h>
-#include <SofaConstraint/UnilateralInteractionConstraint.h>
-
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/ConstraintParams.h>
-
+#include <sofa/component/constraint/lagrangian/model/UnilateralInteractionConstraint.h>
 
 double TimeResolution = 0.0;
 double TimeCount = 0.0;
@@ -63,8 +59,8 @@ using sofa::core::MultiVecCoordId;
 using sofa::core::ConstMultiVecCoordId;
 using sofa::core::ConstVecCoordId;
 
-using sofa::component::constraintset::UnilateralConstraintResolution;
-using sofa::component::constraintset::UnilateralConstraintResolutionWithFriction;
+using sofa::component::constraint::lagrangian::model::UnilateralConstraintResolution;
+using sofa::component::constraint::lagrangian::model::UnilateralConstraintResolutionWithFriction;
 
 template<class DataTypes>
 ImplicitSurfaceAdaptiveConstraint<DataTypes>::ImplicitSurfaceAdaptiveConstraint(MechanicalState* object1, MechanicalState* object2)

--- a/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.inl
+++ b/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.inl
@@ -19,11 +19,10 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFA_COMPONENT_CONSTRAINT_IMPLICITSURFACEADAPTIVECONSTRAINT_INL
-#define SOFA_COMPONENT_CONSTRAINT_IMPLICITSURFACEADAPTIVECONSTRAINT_INL
+#pragma once
 
 
-#include "ImplicitSurfaceAdaptiveConstraint.h"
+#include <BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.h>
 
 #include <sofa/helper/system/thread/CTime.h>
 #include <sofa/defaulttype/RigidTypes.h>
@@ -45,13 +44,7 @@ double TimeProjection2= 0.0;
 //#define DEBUG_DFREE_COMPUTATION
 
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace constraint
+namespace sofa::component::constraint
 {
 
 using sofa::core::VecCoordId;
@@ -774,10 +767,4 @@ void ImplicitSurfaceAdaptiveConstraintResolution<DataTypes>::resolution(int line
     force[line]=0.0;
 }
 
-} // namespace constraint
-
-} // namespace component
-
-} // namespace sofa
-
-#endif
+} // namespace sofa::component::constraint


### PR DESCRIPTION
Always going under the radar because it needs SofaImplicitField...

\+ some cleanup