### PR TITLE
[Component] Clean header includes and typedef in AdaptiveBeamForceFieldAndMass

### DIFF
--- a/BeamAdapter_test/BeamInterpolation_test.cpp
+++ b/BeamAdapter_test/BeamInterpolation_test.cpp
@@ -22,7 +22,7 @@
 #include <sofa/testing/BaseSimulationTest.h>
 
 #include <sofa/helper/BackTrace.h>
-
+#include <sofa/core/ExecParams.h>
 #include <sofa/component/statecontainer/MechanicalObject.h>
 
 using sofa::core::topology::BaseMeshTopology ;
@@ -88,8 +88,8 @@ struct BeamInterpolationTest : public  sofa::testing::BaseSimulationTest,
             Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1", scene.c_str(), scene.size());
             ASSERT_NE(root.get(), nullptr);
 
-            root->init(ExecParams::defaultInstance());
-            root->reinit(ExecParams::defaultInstance()) ;
+            root->init(core::ExecParams::defaultInstance());
+            root->reinit(core::ExecParams::defaultInstance()) ;
         }else if(lines[2]=="W")
         {
             EXPECT_MSG_EMIT(Error) ;
@@ -98,8 +98,8 @@ struct BeamInterpolationTest : public  sofa::testing::BaseSimulationTest,
             Node::SPtr root = SceneLoaderXML::loadFromMemory ( "test1", scene.c_str(), scene.size());
             ASSERT_NE(root.get(), nullptr);
 
-            root->init(ExecParams::defaultInstance());
-            root->reinit(ExecParams::defaultInstance()) ;
+            root->init(core::ExecParams::defaultInstance());
+            root->reinit(core::ExecParams::defaultInstance()) ;
         }
     }
 };

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.cpp
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.cpp
@@ -30,12 +30,12 @@
 // Copyright: See COPYING file that comes with this distribution
 //
 //
+#define SOFA_PLUGIN_BEAMADAPTER_ADAPTIVEBEAMFORCEFIELD_CPP
 
 //////////////////////// Inclusion of headers...from wider to narrower/closer //////////////////////
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/core/ObjectFactory.h>
 
-#define SOFA_PLUGIN_BEAMADAPTER_ADAPTIVEBEAMFORCEFIELD_CPP
 #include <BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl>
 
 namespace sofa::component::forcefield
@@ -43,10 +43,6 @@ namespace sofa::component::forcefield
 
 namespace _adaptivebeamforcefieldandmass_
 {
-
-using sofa::core::RegisterObject ;
-using sofa::defaulttype::Rigid3fTypes;
-using sofa::defaulttype::Rigid3dTypes;
 
 /////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
 ///
@@ -57,11 +53,11 @@ using sofa::defaulttype::Rigid3dTypes;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 //TODO(damien): Il faut remplacer les descriptions dans RegisterObject par un vrai description
-static int AdaptiveBeamForceFieldAndMassClass = RegisterObject("Adaptive Beam finite elements")
-.add< AdaptiveBeamForceFieldAndMass<Rigid3Types> >()
+const static int AdaptiveBeamForceFieldAndMassClass = sofa::core::RegisterObject("Adaptive Beam finite elements")
+.add< AdaptiveBeamForceFieldAndMass<sofa::defaulttype::Rigid3Types> >()
 ;
 
-template class SOFA_BEAMADAPTER_API AdaptiveBeamForceFieldAndMass<Rigid3Types>;
+template class SOFA_BEAMADAPTER_API AdaptiveBeamForceFieldAndMass<sofa::defaulttype::Rigid3Types>;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
@@ -99,7 +99,8 @@ public:
 
     using BInterpolation = sofa::component::fem::BeamInterpolation<DataTypes>;
     using WireRestShape = sofa::component::engine::WireRestShape<DataTypes>;
-  
+    using Mass<DataTypes>::mstate;
+
 protected:
 
     /*!

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
@@ -154,14 +154,14 @@ public:
     void addMBKToMatrix(const MechanicalParams* mparams, const MultiMatrixAccessor* matrix) override;
 
     //TODO(dmarchal 2017-05-17) So what do we do ? For who is this message intended for ? How can we make this code "more" manageable.
-    virtual  void accFromF(const MechanicalParams* mparams, DataVecDeriv& , const DataVecDeriv& ) override
+    void accFromF(const MechanicalParams* mparams, DataVecDeriv& , const DataVecDeriv& ) override
     {
         SOFA_UNUSED(mparams);
         msg_error()<<"accFromF can not be implemented easily: It necessitates a solver because M^-1 is not available";
     }
 
     //TODO(dmarchal 2017-05-17) So what do we do ? For who is this message intended for ? How can we make this code "more" manageable.
-    virtual double getKineticEnergy(const MechanicalParams* mparams, const DataVecDeriv& )  const override ///< vMv/2 using dof->getV()
+    double getKineticEnergy(const MechanicalParams* mparams, const DataVecDeriv& )  const override ///< vMv/2 using dof->getV()
     {
         SOFA_UNUSED(mparams);
         msg_error() << "getKineticEnergy not yet implemented";
@@ -169,7 +169,7 @@ public:
     }
 
     //TODO(dmarchal 2017-05-17) So what do we do ? For who is this message intended for ? How can we make this code "more" manageable.
-    virtual void addGravityToV(const MechanicalParams* mparams, DataVecDeriv& ) override
+    void addGravityToV(const MechanicalParams* mparams, DataVecDeriv& ) override
     {
         SOFA_UNUSED(mparams);
         msg_error() << "addGravityToV not implemented yet";
@@ -180,14 +180,12 @@ public:
     /////////////////////////////////////
     /// ForceField Interface
     /////////////////////////////////////
-    virtual void addForce(const MechanicalParams* mparams,
-                          DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override;
+    void addForce(const MechanicalParams* mparams, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override;
 
-    virtual void addDForce(const MechanicalParams* mparams,
-                           DataVecDeriv&   datadF , const DataVecDeriv&   datadX ) override;
+    void addDForce(const MechanicalParams* mparams, DataVecDeriv&   datadF , const DataVecDeriv&   datadX ) override;
 
     //TODO(dmarchal 2017-05-17) So what do we do ? For who is this message intended for ? How can we make this code "more" manageable.
-    virtual double getPotentialEnergy(const MechanicalParams* mparams, const DataVecCoord& )const override
+    double getPotentialEnergy(const MechanicalParams* mparams, const DataVecCoord& )const override
     {
         SOFA_UNUSED(mparams);
         msg_error()<<"getPotentialEnergy not yet implemented"; 

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
@@ -91,7 +91,9 @@ public:
 
     using Vec3 = sofa::type::Vec<3, Real>;
     using Vec6 = sofa::type::Vec<6, Real>;
+    using Vec6NoInit = sofa::type::VecNoInit<6, Real>;
     using Matrix6x6 = sofa::type::Mat<6, 6, Real>;
+    using Matrix6x6NoInit = sofa::type::MatNoInit<6, 6, Real>;
     using Transform = typename sofa::defaulttype::SolidTypes<Real>::Transform;
     using SpatialVector = typename sofa::defaulttype::SolidTypes<Real>::SpatialVector;
 
@@ -125,9 +127,9 @@ protected:
         }
         ~BeamLocalMatrices(){}
 
-        Matrix6x6 m_K00, m_K01, m_K10, m_K11; /// stiffness Matrices
-        Matrix6x6 m_M00, m_M01, m_M10, m_M11; /// mass Matrices
-        Matrix6x6 m_A0Ref, m_A1Ref;   /// adjoint Matrices
+        Matrix6x6NoInit m_K00, m_K01, m_K10, m_K11; /// stiffness Matrices
+        Matrix6x6NoInit m_M00, m_M01, m_M10, m_M11; /// mass Matrices
+        Matrix6x6NoInit m_A0Ref, m_A1Ref;   /// adjoint Matrices
     };
 
 public:

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
@@ -35,17 +35,6 @@
 //////////////////////// Inclusion of headers...from wider to narrower/closer //////////////////////
 #include <sofa/core/behavior/ForceField.h>
 #include <sofa/core/behavior/Mass.h>
-#include <sofa/core/objectmodel/Data.h>
-#include <sofa/defaulttype/SolidTypes.h>
-#include <sofa/core/topology/BaseMeshTopology.h>
-
-#include <sofa/type/vector.h>
-#include <sofa/type/Vec.h>
-#include <sofa/type/Mat.h>
-
-#include <sofa/core/objectmodel/BaseObject.h>
-#include <sofa/core/visual/VisualParams.h>
-
 #include <BeamAdapter/config.h>
 #include <BeamAdapter/component/BeamInterpolation.h>
 #include <BeamAdapter/component/engine/WireRestShape.h>
@@ -71,19 +60,9 @@ namespace sofa::component::forcefield
 namespace _adaptivebeamforcefieldandmass_
 {
 
-using sofa::type::vector;
-using sofa::component::engine::WireRestShape ;
-using sofa::component::fem::BeamInterpolation ;
-using sofa::core::behavior::MultiMatrixAccessor ;
-using sofa::core::visual::VisualParams ;
-using sofa::core::behavior::Mass ;
-using sofa::core::MechanicalParams ;
-using sofa::type::Vec ;
-using sofa::type::Mat ;
-using sofa::defaulttype::Rigid3Types ;
-using core::objectmodel::Data ;
-using core::topology::BaseMeshTopology;
-using sofa::defaulttype::SolidTypes;
+using sofa::core::behavior::MultiMatrixAccessor;
+using sofa::core::visual::VisualParams;
+using sofa::core::MechanicalParams;
 
 /*!
  * \class AdaptiveBeamForceFieldAndMass
@@ -94,42 +73,37 @@ using sofa::defaulttype::SolidTypes;
  * https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/components-and-datas/
  */
 template<class DataTypes>
-class AdaptiveBeamForceFieldAndMass : public Mass<DataTypes>
+class AdaptiveBeamForceFieldAndMass : public core::behavior::Mass<DataTypes>
 {
 public:
-
     SOFA_CLASS(SOFA_TEMPLATE(AdaptiveBeamForceFieldAndMass,DataTypes),
                SOFA_TEMPLATE(core::behavior::Mass,DataTypes));
 
-    typedef typename DataTypes::VecCoord VecCoord;
-    typedef typename DataTypes::VecDeriv VecDeriv;
-    typedef typename DataTypes::VecReal VecReal;
-    typedef VecCoord Vector;
-    typedef typename DataTypes::Coord Coord;
-    typedef typename DataTypes::Deriv Deriv;
-    typedef typename Coord::value_type Real;
-    typedef Data<VecCoord> DataVecCoord;
-    typedef Data<VecDeriv> DataVecDeriv;
-    typedef BeamInterpolation<DataTypes> BInterpolation;
+    using Coord = typename DataTypes::Coord;
+    using VecCoord = typename DataTypes::VecCoord;
+    using Real = typename Coord::value_type;
 
-    typedef unsigned int Index;
-    typedef BaseMeshTopology::Edge Element;
-    typedef type::vector<BaseMeshTopology::Edge> VecElement;
-    typedef type::vector<unsigned int> VecIndex;
+    using Deriv = typename DataTypes::Deriv;
+    using VecDeriv = typename DataTypes::VecDeriv;
 
-    typedef typename SolidTypes<Real>::Transform Transform;
-    typedef typename SolidTypes<Real>::SpatialVector SpatialVector;
+    using DataVecCoord = Data<VecCoord>;
+    using DataVecDeriv = Data<VecDeriv>;
 
-    typedef Vec<3, Real> Vec3;
-    typedef Vec<6, Real> Vec6;          ///< the displacement vector
-    typedef Mat<6, 6, Real> Matrix6x6;
+    using Vec3 = sofa::type::Vec<3, Real>;
+    using Vec6 = sofa::type::Vec<6, Real>;
+    using Matrix6x6 = sofa::type::Mat<6, 6, Real>;
+    using Transform = typename sofa::defaulttype::SolidTypes<Real>::Transform;
+    using SpatialVector = typename sofa::defaulttype::SolidTypes<Real>::SpatialVector;
+
+    using BInterpolation = sofa::component::fem::BeamInterpolation<DataTypes>;
+    using WireRestShape = sofa::component::engine::WireRestShape<DataTypes>;
+  
+protected:
 
     /*!
      * \class BeamLocalMatrices
-     * @brief BeamLocalMatrices Class
-     */
-protected:
-
+    * @brief BeamLocalMatrices Class
+    */
     class BeamLocalMatrices{
 
     public:
@@ -157,7 +131,6 @@ protected:
     };
 
 public:
-
     AdaptiveBeamForceFieldAndMass( ) ;
     virtual ~AdaptiveBeamForceFieldAndMass() = default;
 
@@ -233,8 +206,8 @@ public:
 
 protected :
 
-    SingleLink<AdaptiveBeamForceFieldAndMass<DataTypes>, BInterpolation          , BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_interpolation;
-    SingleLink<AdaptiveBeamForceFieldAndMass<DataTypes>, WireRestShape<DataTypes>, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_instrumentParameters;
+    SingleLink<AdaptiveBeamForceFieldAndMass<DataTypes>, BInterpolation, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_interpolation;
+    SingleLink<AdaptiveBeamForceFieldAndMass<DataTypes>, WireRestShape, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_instrumentParameters;
 
     void applyMassLarge( VecDeriv& df, const VecDeriv& dx, int bIndex, Index nd0Id, Index nd1Id, const double &factor);
     void applyStiffnessLarge( VecDeriv& df, const VecDeriv& dx, int beam, Index nd0Id, Index nd1Id, const double &factor );
@@ -242,9 +215,6 @@ protected :
 
     Vec3 m_gravity;
     type::vector<BeamLocalMatrices> m_localBeamMatrices;
-
-    using Mass<DataTypes>::getContext;
-    using Mass<DataTypes>::mstate;
 
 private:
 
@@ -254,7 +224,7 @@ private:
 
 /// Instantiate the templates so that they are not instiated in each translation unit (see )
 #if !defined(SOFA_PLUGIN_BEAMADAPTER_ADAPTIVEBEAMFORCEFIELD_CPP)
-extern template class SOFA_BEAMADAPTER_API AdaptiveBeamForceFieldAndMass<Rigid3Types> ;
+extern template class SOFA_BEAMADAPTER_API AdaptiveBeamForceFieldAndMass<sofa::defaulttype::Rigid3Types> ;
 #endif
 
 } /// namespace _adaptivebeamforcefieldandmass_

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
@@ -138,17 +138,17 @@ public:
     /////////////////////////////////////
     /// This is inhereted from BaseObject
     /////////////////////////////////////
-    virtual void init() override ;
-    virtual void reinit() override ;
-    virtual void draw(const VisualParams* vparams) override ;
+    void init() override ;
+    void reinit() override ;
+    void draw(const VisualParams* vparams) override ;
 
 
     /////////////////////////////////////
     /// Mass Interface
     /////////////////////////////////////
-    virtual void addMDx(const MechanicalParams* mparams, DataVecDeriv& f, const DataVecDeriv& dx, double factor) override;
-    virtual void addMToMatrix(const MechanicalParams *mparams, const MultiMatrixAccessor* matrix) override;
-    virtual void addMBKToMatrix(const MechanicalParams* mparams, const MultiMatrixAccessor* matrix) override;
+    void addMDx(const MechanicalParams* mparams, DataVecDeriv& f, const DataVecDeriv& dx, double factor) override;
+    void addMToMatrix(const MechanicalParams *mparams, const MultiMatrixAccessor* matrix) override;
+    void addMBKToMatrix(const MechanicalParams* mparams, const MultiMatrixAccessor* matrix) override;
 
     //TODO(dmarchal 2017-05-17) So what do we do ? For who is this message intended for ? How can we make this code "more" manageable.
     virtual  void accFromF(const MechanicalParams* mparams, DataVecDeriv& , const DataVecDeriv& ) override

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
@@ -99,7 +99,7 @@ public:
 
     using BInterpolation = sofa::component::fem::BeamInterpolation<DataTypes>;
     using WireRestShape = sofa::component::engine::WireRestShape<DataTypes>;
-    using Mass<DataTypes>::mstate;
+    using core::behavior::Mass<DataTypes>::mstate;
 
 protected:
 

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
@@ -91,7 +91,7 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::reinit()
 template <class DataTypes>
 void AdaptiveBeamForceFieldAndMass<DataTypes>::computeGravityVector()
 {
-    Vec3 gravity = getContext()->getGravity();
+    Vec3 gravity = this->getContext()->getGravity();
 
     auto _G = sofa::helper::getWriteOnlyAccessor(d_dataG);
     _G.resize(l_interpolation->getStateSize());

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
@@ -32,24 +32,11 @@
 //
 #pragma once
 
-#include <sofa/core/behavior/ForceField.inl>
 #include <BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h>
-
-#include <sofa/core/topology/BaseMeshTopology.h>
-#include <sofa/helper/decompose.h>
-
-
-#include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/defaulttype/VecTypes.h>
-#include <sofa/defaulttype/RigidTypes.h>
-#include <sofa/helper/OptionsGroup.h>
-
-#include <sofa/gl/Cylinder.h>
-#include <sofa/simulation/Simulation.h>
-#include <sofa/gl/Axis.h>
+#include <sofa/core/behavior/MultiMatrixAccessor.h>
+#include <sofa/core/MechanicalParams.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/ScopedAdvancedTimer.h>
-
 
 
 namespace sofa::component::forcefield

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
@@ -128,8 +128,7 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::computeStiffness(int beam, BeamLo
     l_interpolation->getYoungModulusAtX(beam,x_curv, _E, _nu);
 
     /// material parameters
-    Real _G;
-    _G=_E/(2.0*(1.0+_nu));
+    Real _G = _E / (2.0 * (1.0 + _nu));
 
     /// interpolation & geometrical parameters
     Real _A, _L, _Iy, _Iz, _Asy, _Asz, _J;
@@ -281,7 +280,7 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::applyStiffnessLarge( VecDeriv& df
     if(nd0Id==nd1Id) /// Return in case of rigidification
         return;
 
-    Vec6 U0, U1, u0, u1, f0, f1, F0, F1;
+    Vec6NoInit U0, U1, u0, u1, f0, f1, F0, F1;
     BeamLocalMatrices &beamLocalMatrix = m_localBeamMatrices[bIndex];
 
     for (unsigned int i=0; i<6; i++)
@@ -390,12 +389,10 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::addMToMatrix(const MechanicalPara
         l_interpolation->getNodeIndices( b,  node0Idx, node1Idx );
 
         /// matrices in global frame
-        Matrix6x6 M00, M01, M10, M11;
-
-        M00=bLM.m_A0Ref.multTranspose( ( bLM.m_M00 * bLM.m_A0Ref  )  );
-        M01=bLM.m_A0Ref.multTranspose( ( bLM.m_M01 * bLM.m_A1Ref  )  );
-        M10=bLM.m_A1Ref.multTranspose( ( bLM.m_M10 * bLM.m_A0Ref  )  );
-        M11=bLM.m_A1Ref.multTranspose( ( bLM.m_M11 * bLM.m_A1Ref  )  );
+        Matrix6x6 M00 = bLM.m_A0Ref.multTranspose((bLM.m_M00 * bLM.m_A0Ref));
+        Matrix6x6 M01 = bLM.m_A0Ref.multTranspose((bLM.m_M01 * bLM.m_A1Ref));
+        Matrix6x6 M10 = bLM.m_A1Ref.multTranspose((bLM.m_M10 * bLM.m_A0Ref));
+        Matrix6x6 M11 = bLM.m_A1Ref.multTranspose((bLM.m_M11 * bLM.m_A1Ref));
 
         int index0[6], index1[6];
         for (int i=0;i<6;i++)
@@ -444,12 +441,10 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::addMBKToMatrix(const MechanicalPa
         if(node0Idx!=node1Idx) // no rigidification
         {
             // matrices in global frame
-            Matrix6x6 K00, K01, K10, K11;
-
-            K00=bLM.m_A0Ref.multTranspose( ( bLM.m_K00 * bLM.m_A0Ref  )  );
-            K01=bLM.m_A0Ref.multTranspose( ( bLM.m_K01 * bLM.m_A1Ref  )  );
-            K10=bLM.m_A1Ref.multTranspose( ( bLM.m_K10 * bLM.m_A0Ref  )  );
-            K11=bLM.m_A1Ref.multTranspose( ( bLM.m_K11 * bLM.m_A1Ref  )  );
+            Matrix6x6 K00 = bLM.m_A0Ref.multTranspose((bLM.m_K00 * bLM.m_A0Ref));
+            Matrix6x6 K01 = bLM.m_A0Ref.multTranspose((bLM.m_K01 * bLM.m_A1Ref));
+            Matrix6x6 K10 = bLM.m_A1Ref.multTranspose((bLM.m_K10 * bLM.m_A0Ref));
+            Matrix6x6 K11 = bLM.m_A1Ref.multTranspose((bLM.m_K11 * bLM.m_A1Ref));
 
             for (int i=0;i<6;i++)
             {
@@ -464,12 +459,10 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::addMBKToMatrix(const MechanicalPa
         }
 
         // matrices in global frame
-        Matrix6x6 M00, M01, M10, M11;
-
-        M00=bLM.m_A0Ref.multTranspose( ( bLM.m_M00 * bLM.m_A0Ref  )  );
-        M01=bLM.m_A0Ref.multTranspose( ( bLM.m_M01 * bLM.m_A1Ref  )  );
-        M10=bLM.m_A1Ref.multTranspose( ( bLM.m_M10 * bLM.m_A0Ref  )  );
-        M11=bLM.m_A1Ref.multTranspose( ( bLM.m_M11 * bLM.m_A1Ref  )  );
+        Matrix6x6 M00 = bLM.m_A0Ref.multTranspose((bLM.m_M00 * bLM.m_A0Ref));
+        Matrix6x6 M01 = bLM.m_A0Ref.multTranspose((bLM.m_M01 * bLM.m_A1Ref));
+        Matrix6x6 M10 = bLM.m_A1Ref.multTranspose((bLM.m_M10 * bLM.m_A0Ref));
+        Matrix6x6 M11 = bLM.m_A1Ref.multTranspose((bLM.m_M11 * bLM.m_A1Ref));
 
         for (int i=0;i<6;i++)
         {
@@ -591,7 +584,7 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::addForce (const MechanicalParams*
         SpatialVector u1 = local_H_local1.CreateSpatialVector() - local_H_local1_rest.CreateSpatialVector();
 
         /// 3. put the result in a Vec6
-        Vec6 U0local, U1local;
+        Vec6NoInit U0local, U1local;
 
         for (unsigned int i=0; i<3; i++)
         {
@@ -698,11 +691,10 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::addKToMatrix(const MechanicalPara
             continue;
 
         // matrices in global frame
-        Matrix6x6 K00, K01, K10, K11;
-        K00=beamLocalMatrix.m_A0Ref.multTranspose( ( beamLocalMatrix.m_K00 * beamLocalMatrix.m_A0Ref  )  );
-        K01=beamLocalMatrix.m_A0Ref.multTranspose( ( beamLocalMatrix.m_K01 * beamLocalMatrix.m_A1Ref  )  );
-        K10=beamLocalMatrix.m_A1Ref.multTranspose( ( beamLocalMatrix.m_K10 * beamLocalMatrix.m_A0Ref  )  );
-        K11=beamLocalMatrix.m_A1Ref.multTranspose( ( beamLocalMatrix.m_K11 * beamLocalMatrix.m_A1Ref  )  );
+        Matrix6x6 K00 = beamLocalMatrix.m_A0Ref.multTranspose((beamLocalMatrix.m_K00 * beamLocalMatrix.m_A0Ref));
+        Matrix6x6 K01 = beamLocalMatrix.m_A0Ref.multTranspose((beamLocalMatrix.m_K01 * beamLocalMatrix.m_A1Ref));
+        Matrix6x6 K10 = beamLocalMatrix.m_A1Ref.multTranspose((beamLocalMatrix.m_K10 * beamLocalMatrix.m_A0Ref));
+        Matrix6x6 K11 = beamLocalMatrix.m_A1Ref.multTranspose((beamLocalMatrix.m_K11 * beamLocalMatrix.m_A1Ref));
 
         int index0[6], index1[6];
         for (int i=0;i<6;i++)

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
@@ -377,7 +377,7 @@ template<class DataTypes>
 void AdaptiveBeamForceFieldAndMass<DataTypes>::addMToMatrix(const MechanicalParams *mparams,
                                                             const MultiMatrixAccessor* matrix)
 {
-    MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate);
+    MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(mstate);
     Real mFact = (Real)mparams->mFactor();
 
     unsigned int numBeams = l_interpolation->getNumBeams();
@@ -419,7 +419,7 @@ template<class DataTypes>
 void AdaptiveBeamForceFieldAndMass<DataTypes>::addMBKToMatrix(const MechanicalParams* mparams,
                                                               const MultiMatrixAccessor* matrix)
 {
-    MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(this->mstate);
+    MultiMatrixAccessor::MatrixRef r = matrix->getMatrix(mstate);
     Real kFact = (Real)mparams->kFactor();
     Real mFact = (Real)mparams->mFactor();
 


### PR DESCRIPTION
- Clean header includes
- update all typedef by using and remove unused one
- Update mat6x6 init in code to avoid creation followed by copy. 