### PR TITLE
[Mapping] Clean and optimize AdaptiveBeamMapping

### DIFF
--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
@@ -205,21 +205,6 @@ public:
     using Mapping<TIn, TOut>::fromModel ;
     ////////////////////////////////////////////////////////////////////////////
 
-    // if this component was built without the support of the STL execution feature
-    // inform the scene user that this is not supported.
-#if not HAS_SUPPORT_STL_PARALLELISM
-    void parse(core::objectmodel::BaseObjectDescription* args) override
-    {
-        const char* arg = args->getAttribute("parallelMapping");
-        if (arg)
-        {
-            msg_warning() << "The attribute 'parallelMapping' was set but this version of AdaptiveBeamMapping does not support it. " << msgendl;
-        }
-
-        Inherit1::parse(args);
-    }
-#endif // HAS_SUPPORT_STL_PARALLELISM
-
  protected:
 
     TopologyContainer* m_topology;

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
@@ -137,6 +137,11 @@ public:
        /// -The first denote the curvilinear coordinate
        /// -The two followings denote the planar coordinate on the perpendicular cross section on the curve
        Vec3 baryPoint{};
+
+       PosPointDefinition() = default;
+       PosPointDefinition(unsigned int b, Vec3&& bary)
+           : beamId(b), baryPoint(std::move(bary))
+       {}
     } ;
 
 public:

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
@@ -54,10 +54,11 @@
 #define HAS_SUPPORT_STL_PARALLELISM (_MSC_VER > 1921)
 #elif defined(__GNUC__)
 #define HAS_SUPPORT_STL_PARALLELISM  (__GNUC__ > 9)
+#elif defined(__clang_major__)
+#define HAS_SUPPORT_STL_PARALLELISM  (__clang_major__ > 10)
 #else
 #define HAS_SUPPORT_STL_PARALLELISM  false
 #endif
-
 
 #if HAS_SUPPORT_STL_PARALLELISM
 #include <execution>
@@ -225,7 +226,7 @@ public:
     // if this component was built without the support of the STL execution feature
     // inform the scene user that this is not supported.
 #if not HAS_SUPPORT_STL_PARALLELISM
-    void parse(core::objectmodel::BaseObjectDescription* args)
+    void parse(core::objectmodel::BaseObjectDescription* args) override
     {
         const char* arg = args->getAttribute("parallelMapping");
         if (arg)

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
@@ -48,22 +48,6 @@
 #include <BeamAdapter/component/BeamInterpolation.h>
 #include <BeamAdapter/component/controller/AdaptiveBeamController.h>
 
-
-// execution policies only supported by MSVC >=2019 and GCC >=10
-#ifdef _MSC_VER
-#define HAS_SUPPORT_STL_PARALLELISM (_MSC_VER > 1921)
-#elif defined(__GNUC__)
-#define HAS_SUPPORT_STL_PARALLELISM  (__GNUC__ > 9)
-#elif defined(__clang_major__)
-#define HAS_SUPPORT_STL_PARALLELISM  (__clang_major__ > 10)
-#else
-#define HAS_SUPPORT_STL_PARALLELISM  false
-#endif
-
-#if HAS_SUPPORT_STL_PARALLELISM
-#include <execution>
-#endif
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Forward declarations, see https://en.wikipedia.org/wiki/Forward_declaration
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -168,9 +152,7 @@ public:
     Data<std::string> d_inputMapName;		  /*!< if contactDuplicate==true, it provides the name of the input mapping */
     Data<double> d_nbPointsPerBeam;		  /*!< if non zero, we will adapt the points depending on the discretization, with this num of points per beam (compatible with useCurvAbs)*/
     Data<type::vector<Real>> d_segmentsCurvAbs; /*!< (output) the abscissa of each created point on the collision model */
-#if HAS_SUPPORT_STL_PARALLELISM
     Data<bool> d_parallelMapping;           /*!< flag to enable parallel internal computation of apply/applyJ */
-#endif // HAS_SUPPORT_STL_PARALLELISM
 
     SingleLink<AdaptiveBeamMapping<TIn, TOut>,
                BInterpolation, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_adaptativebeamInterpolation;

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
@@ -130,14 +130,14 @@ public:
     typedef BeamInterpolation<TIn> BInterpolation;
 
     typedef std::pair<unsigned int, Vec3> BeamIdAndBaryCoord;
-    typedef struct
+    struct PosPointDefinition
     {
-       unsigned int beamId;
+       unsigned int beamId = 0;
        /// A bary point has 3 components
        /// -The first denote the curvilinear coordinate
        /// -The two followings denote the planar coordinate on the perpendicular cross section on the curve
-       Vec3 baryPoint;
-    } PosPointDefinition;
+       Vec3 baryPoint{};
+    } ;
 
 public:
 

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
@@ -148,7 +148,7 @@ public:
     Data<std::string> d_inputMapName;		  /*!< if contactDuplicate==true, it provides the name of the input mapping */
     Data<double> d_nbPointsPerBeam;		  /*!< if non zero, we will adapt the points depending on the discretization, with this num of points per beam (compatible with useCurvAbs)*/
     Data<type::vector<Real>> d_segmentsCurvAbs; /*!< (output) the abscissa of each created point on the collision model */
-    Data<bool> d_parallelApplyJ;           /*!< flag to enable parallel internal computation of applyJ */
+    Data<bool> d_parallelMapping;           /*!< flag to enable parallel internal computation of apply/applyJ */
 
     SingleLink<AdaptiveBeamMapping<TIn, TOut>,
                BInterpolation, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_adaptativebeamInterpolation;

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
@@ -148,6 +148,7 @@ public:
     Data<std::string> d_inputMapName;		  /*!< if contactDuplicate==true, it provides the name of the input mapping */
     Data<double> d_nbPointsPerBeam;		  /*!< if non zero, we will adapt the points depending on the discretization, with this num of points per beam (compatible with useCurvAbs)*/
     Data<type::vector<Real>> d_segmentsCurvAbs; /*!< (output) the abscissa of each created point on the collision model */
+    Data<bool> d_parallelApplyJ;           /*!< flag to enable parallel internal computation of applyJ */
 
     SingleLink<AdaptiveBeamMapping<TIn, TOut>,
                BInterpolation, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_adaptativebeamInterpolation;

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -642,7 +642,7 @@ void AdaptiveBeamMapping< TIn, TOut>::computeDistribution()
                     for (; posInBeam <= 1.0; posInBeam += step)
                     {
                         waSegmentsCurvAbs.push_back(segStart + segLength * posInBeam);
-                        m_pointBeamDistribution.emplace_back( b, { posInBeam, 0.0, 0.0} );
+                        m_pointBeamDistribution.emplace_back( b, Vec3{ posInBeam, 0.0, 0.0} );
                     }
 
                     posInBeam -= 1.0;
@@ -652,7 +652,7 @@ void AdaptiveBeamMapping< TIn, TOut>::computeDistribution()
                 {
                     // Last point
                     waSegmentsCurvAbs.push_back(segEnd);
-                    m_pointBeamDistribution.emplace_back(PosPointDefinition{ numBeams - 1, { 1.0, 0.0, 0.0} });
+                    m_pointBeamDistribution.emplace_back( numBeams - 1, Vec3{ 1.0, 0.0, 0.0} );
                 }
 
                 BaseMeshTopology* topo = this->getContext()->getMeshTopology();
@@ -676,7 +676,7 @@ void AdaptiveBeamMapping< TIn, TOut>::computeDistribution()
 
                     computeIdxAndBaryCoordsForAbs(b, xBary,  xAbs );
 
-                    m_pointBeamDistribution.emplace_back(PosPointDefinition{ b, { xBary, points[i][1], points[i][2]} });
+                    m_pointBeamDistribution.emplace_back( b, Vec3{ xBary, points[i][1], points[i][2]});
                 }
             }
         }
@@ -687,7 +687,7 @@ void AdaptiveBeamMapping< TIn, TOut>::computeDistribution()
             {
                 const unsigned int beamId = (int)floor(points[i][0]);
                 msg_warning_when(this->f_printLog.getValue() && (beamId > numBeams-1)) << "Points[" << i << "][0] = " << beamId << " is defined outside of the beam length";
-                m_pointBeamDistribution.emplace_back(PosPointDefinition{ beamId, { points[i][0] - floor(points[i][0]), points[i][1], points[i][2]} });
+                m_pointBeamDistribution.emplace_back( beamId, Vec3{ points[i][0] - floor(points[i][0]), points[i][1], points[i][2]});
             }
         }
     }

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -76,7 +76,7 @@ AdaptiveBeamMapping<TIn,TOut>::AdaptiveBeamMapping(State< In >* from, State< Out
     , d_inputMapName(initData(&d_inputMapName,"nameOfInputMap", "if contactDuplicate==true, it provides the name of the input mapping"))
     , d_nbPointsPerBeam(initData(&d_nbPointsPerBeam, 0.0, "nbPointsPerBeam", "if non zero, we will adapt the points depending on the discretization, with this num of points per beam (compatible with useCurvAbs)"))
     , d_segmentsCurvAbs(initData(&d_segmentsCurvAbs, "segmentsCurvAbs", "the abscissa of each point on the collision model", true, true))
-    , d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation of apply/applyJ"))
+    , d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation"))
     , l_adaptativebeamInterpolation(initLink("interpolation", "Path to the Interpolation component on scene"), interpolation)
     , m_inputMapping(nullptr)
     , m_isSubMapping(isSubMapping)

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -87,7 +87,7 @@ AdaptiveBeamMapping<TIn,TOut>::AdaptiveBeamMapping(State< In >* from, State< Out
     , d_inputMapName(initData(&d_inputMapName,"nameOfInputMap", "if contactDuplicate==true, it provides the name of the input mapping"))
     , d_nbPointsPerBeam(initData(&d_nbPointsPerBeam, 0.0, "nbPointsPerBeam", "if non zero, we will adapt the points depending on the discretization, with this num of points per beam (compatible with useCurvAbs)"))
     , d_segmentsCurvAbs(initData(&d_segmentsCurvAbs, "segmentsCurvAbs", "the abscissa of each point on the collision model", true, true))
-    , d_parallelMapping(initData(&d_parallelMapping, true, "parallelMapping", "flag to enable parallel internal computation of apply/applyJ"))
+    , d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation of apply/applyJ"))
     , l_adaptativebeamInterpolation(initLink("interpolation", "Path to the Interpolation component on scene"), interpolation)
     , m_inputMapping(nullptr)
     , m_isSubMapping(isSubMapping)
@@ -111,7 +111,7 @@ void AdaptiveBeamMapping< TIn, TOut>::init()
 #if not HAS_SUPPORT_STL_PARALLELISM
     if (d_parallelMapping.getValue())
     {
-        msg_error() << "Your compiler does not support STL parallelism, disabling parallel features.";
+        msg_warning() << "Your compiler does not support STL parallelism, disabling parallel features.";
         d_parallelMapping.setValue(false);
     }
 #endif

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -46,7 +46,14 @@
 #include <sofa/core/MechanicalParams.h>
 
 // execution policies only supported by MSVC >=2019 and GCC >=10
-#define HAS_SUPPORT_STL_PARALLELISM _MSC_VER > 1921 || (! defined(__GNUC__) || __GNUC__ > 9)
+#ifdef _MSC_VER
+    #define HAS_SUPPORT_STL_PARALLELISM (_MSC_VER > 1921)
+#elif defined(__GNUC__)
+    #define HAS_SUPPORT_STL_PARALLELISM  (__GNUC__ > 9)
+#else
+    #define HAS_SUPPORT_STL_PARALLELISM  false
+#endif
+
 
 #if HAS_SUPPORT_STL_PARALLELISM
 #include <execution>

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -265,7 +265,7 @@ void AdaptiveBeamMapping< TIn, TOut>::apply(const MechanicalParams* mparams, Dat
 
             if (m_isSubMapping)
             {
-                if (m_idPointSubMap.size() > 0)
+                if (!m_idPointSubMap.empty())
                     out[m_idPointSubMap[elementID]] = pos;
             }
             else
@@ -283,7 +283,7 @@ void AdaptiveBeamMapping< TIn, TOut>::apply(const MechanicalParams* mparams, Dat
     simulation::TaskScheduler* taskScheduler = simulation::MainTaskSchedulerFactory::createInRegistry();
     assert(taskScheduler);
 
-    simulation::forEachRange(execution , *taskScheduler, m_pointBeamDistribution.begin(), m_pointBeamDistribution.end(), apply_impl);
+    simulation::forEachRange(execution, *taskScheduler, m_pointBeamDistribution.begin(), m_pointBeamDistribution.end(), apply_impl);
 
 
     AdvancedTimer::stepEnd("computeNewInterpolation");

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -287,16 +287,13 @@ void AdaptiveBeamMapping< TIn, TOut>::apply(const MechanicalParams* mparams, Dat
     {
         std::for_each(std::execution::par_unseq, m_pointBeamDistribution.begin(), m_pointBeamDistribution.end(), apply_impl);
     }
-    else // standard for-loop for each element (sequential, ordered)
-    {
-        std::for_each(std::execution::seq, m_pointBeamDistribution.begin(), m_pointBeamDistribution.end(), apply_impl);
-    }
-#else
-    for (const auto& p : m_pointBeamDistribution)
-    {
-        apply_impl(p);
-    }
+    else
 #endif // HAS_SUPPORT_STL_PARALLELISM
+for (const auto& p : m_pointBeamDistribution)
+{
+    apply_impl(p);
+}
+
 
     AdvancedTimer::stepEnd("computeNewInterpolation");
 }

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -672,7 +672,7 @@ void AdaptiveBeamMapping< TIn, TOut>::computeDistribution()
             for (unsigned int i=0; i<points.size(); i++)
             {
                 const unsigned int beamId = (int)floor(points[i][0]);
-                msg_warning_when(printLog && (beamId > numBeams-1)) << "Points[" << i << "][0] = " << beamId << " is defined outside of the beam length";
+                msg_warning_when(beamId > numBeams-1) << "Points[" << i << "][0] = " << beamId << " is defined outside of the beam length";
                 m_pointBeamDistribution.emplace_back( beamId, Vec3{ points[i][0] - floor(points[i][0]), points[i][1], points[i][2]});
             }
         }

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -375,7 +375,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJ(const core::MechanicalParams* mpara
 #else
     for (const auto& p : m_pointBeamDistribution)
     {
-        apply_impl(p);
+        applyJ_impl(p);
     }
 #endif // HAS_SUPPORT_STL_PARALLELISM
 

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -341,7 +341,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJ(const core::MechanicalParams* mpara
             SpatialVector vDOF0{ In::getDRot(in[IdxNode0]), In::getDPos(in[IdxNode0]) };
             SpatialVector vDOF1{ In::getDRot(in[IdxNode1]), In::getDPos(in[IdxNode1]) };
 
-            Deriv vResult;
+            Deriv vResult(sofa::type::NOINIT);
 
             applyJonPoint(elementID, vDOF0, vDOF1, vResult, x.ref());
 

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -267,7 +267,7 @@ void AdaptiveBeamMapping< TIn, TOut>::apply(const MechanicalParams* mparams, Dat
     // effective computation for each element in pointBeamDistribution
     auto apply_impl = [&](const PosPointDefinition& pointBeamDistribution)
     {
-        int i = &pointBeamDistribution - &m_pointBeamDistribution[0];
+        const int i = &pointBeamDistribution - &m_pointBeamDistribution[0];
 
         Vec<3, InReal> pos;
         const Vec3 localPos(0., pointBeamDistribution.baryPoint[1], pointBeamDistribution.baryPoint[2]);
@@ -342,7 +342,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJ(const core::MechanicalParams* mpara
     // effective computation for each element in pointBeamDistribution
     auto applyJ_impl = [&](const PosPointDefinition& pointBeamDistribution)
     {
-        int i = &pointBeamDistribution - &m_pointBeamDistribution[0];
+        const int i = &pointBeamDistribution - &m_pointBeamDistribution[0];
 
         unsigned int IdxNode0, IdxNode1;
         l_adaptativebeamInterpolation->getNodeIndices(pointBeamDistribution.beamId, IdxNode0, IdxNode1);
@@ -642,7 +642,7 @@ void AdaptiveBeamMapping< TIn, TOut>::computeDistribution()
                     for (; posInBeam <= 1.0; posInBeam += step)
                     {
                         waSegmentsCurvAbs.push_back(segStart + segLength * posInBeam);
-                        m_pointBeamDistribution.emplace_back(PosPointDefinition{ b, { posInBeam, 0.0, 0.0} });
+                        m_pointBeamDistribution.emplace_back( b, { posInBeam, 0.0, 0.0} );
                     }
 
                     posInBeam -= 1.0;

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -289,10 +289,10 @@ void AdaptiveBeamMapping< TIn, TOut>::apply(const MechanicalParams* mparams, Dat
     }
     else
 #endif // HAS_SUPPORT_STL_PARALLELISM
-for (const auto& p : m_pointBeamDistribution)
-{
-    apply_impl(p);
-}
+    for (const auto& p : m_pointBeamDistribution)
+    {
+        apply_impl(p);
+    }
 
 
     AdvancedTimer::stepEnd("computeNewInterpolation");
@@ -365,16 +365,12 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJ(const core::MechanicalParams* mpara
     {
         std::for_each(std::execution::par_unseq, m_pointBeamDistribution.begin(), m_pointBeamDistribution.end(), applyJ_impl);
     }
-    else // standard for-loop for each element (sequential, ordered)
-    {
-        std::for_each(std::execution::seq, m_pointBeamDistribution.begin(), m_pointBeamDistribution.end(), applyJ_impl);
-    }
-#else
+    else
+#endif // HAS_SUPPORT_STL_PARALLELISM
     for (const auto& p : m_pointBeamDistribution)
     {
         applyJ_impl(p);
     }
-#endif // HAS_SUPPORT_STL_PARALLELISM
 
     if(m_isXBufferUsed)
     {

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -91,7 +91,11 @@ void AdaptiveBeamMapping< TIn, TOut>::init()
         l_adaptativebeamInterpolation.set(dynamic_cast<sofa::core::objectmodel::BaseContext *>(this->getContext())->get<BInterpolation>());
 
     if (!l_adaptativebeamInterpolation)
+    {
         msg_error() <<"No Beam Interpolation found, the component can not work.";
+
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+    }
 }
 
 
@@ -242,7 +246,8 @@ void AdaptiveBeamMapping< TIn, TOut>::apply(const MechanicalParams* mparams, Dat
     AdvancedTimer::stepBegin("computeNewInterpolation");
     for(unsigned int i=0; i<m_pointBeamDistribution.size(); i++)
     {
-        PosPointDefinition pointBeamDistribution = m_pointBeamDistribution[i];
+        const PosPointDefinition& pointBeamDistribution = m_pointBeamDistribution[i];
+
         Vec<3, InReal> pos;
         const Vec3 localPos(0.,pointBeamDistribution.baryPoint[1],pointBeamDistribution.baryPoint[2]);
         l_adaptativebeamInterpolation->interpolatePointUsingSpline(pointBeamDistribution.beamId, pointBeamDistribution.baryPoint[0], localPos, in, pos, false, xtest);
@@ -429,7 +434,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJT(const core::ConstraintParams* cpar
             }
 
             if(indexIn<m_pointBeamDistribution.size()){
-                PosPointDefinition  ppd = m_pointBeamDistribution[indexIn];
+                const PosPointDefinition&  ppd = m_pointBeamDistribution[indexIn];
                 unsigned int IdxNode0, IdxNode1;
                 l_adaptativebeamInterpolation->getNodeIndices(ppd.beamId,IdxNode0,IdxNode1);
 
@@ -460,8 +465,8 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJT(const core::ConstraintParams* cpar
 template <class TIn, class TOut>
 void AdaptiveBeamMapping< TIn, TOut>::bwdInit()
 {
-
-    const auto ptsSize = d_points.getValue().size();
+    const auto& pts = d_points.getValue();
+    const auto ptsSize = pts.size();
 
     if (ptsSize == 0)
     {
@@ -482,8 +487,6 @@ void AdaptiveBeamMapping< TIn, TOut>::bwdInit()
             }
         }
     }
-
-    const sofa::type::vector<Vec3>& pts = d_points.getValue();
 
     bool curvAbs = this->d_useCurvAbs.getValue();
     if (curvAbs)
@@ -701,7 +704,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJonPoint(unsigned int i, SpatialVecto
 {
 
     // 1. get the curvilinear abs;
-    PosPointDefinition  ppd = m_pointBeamDistribution[i];
+    const PosPointDefinition&  ppd = m_pointBeamDistribution[i];
 
     // 2. get the indices
     unsigned int IdxNode0, IdxNode1;
@@ -762,7 +765,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJonPoint(unsigned int i, SpatialVecto
 template <class TIn, class TOut>
 void AdaptiveBeamMapping< TIn, TOut>::applyJTonPoint(unsigned int i, const Deriv& finput, SpatialVector& FNode0output, SpatialVector& FNode1output, const InVecCoord& x)
 {
-    PosPointDefinition  pointBeamDistribution = m_pointBeamDistribution[i];
+    const PosPointDefinition&  pointBeamDistribution = m_pointBeamDistribution[i];
     const Vec3 localPos(0.,pointBeamDistribution.baryPoint[1],pointBeamDistribution.baryPoint[2]);
     const Vec3 Fin(finput[0], finput[1], finput[2]);
     l_adaptativebeamInterpolation->MapForceOnNodeUsingSpline(pointBeamDistribution.beamId, pointBeamDistribution.baryPoint[0], localPos, x, Fin, FNode0output, FNode1output );

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -373,7 +373,7 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJ(const core::MechanicalParams* mpara
         std::for_each(std::execution::seq, m_pointBeamDistribution.begin(), m_pointBeamDistribution.end(), applyJ_impl);
     }
 #else
-    for (const auto& p : applyJ_impl)
+    for (const auto& p : m_pointBeamDistribution)
     {
         apply_impl(p);
     }

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -45,20 +45,6 @@
 #include <sofa/core/ConstraintParams.h>
 #include <sofa/core/MechanicalParams.h>
 
-// execution policies only supported by MSVC >=2019 and GCC >=10
-#ifdef _MSC_VER
-    #define HAS_SUPPORT_STL_PARALLELISM (_MSC_VER > 1921)
-#elif defined(__GNUC__)
-    #define HAS_SUPPORT_STL_PARALLELISM  (__GNUC__ > 9)
-#else
-    #define HAS_SUPPORT_STL_PARALLELISM  false
-#endif
-
-
-#if HAS_SUPPORT_STL_PARALLELISM
-#include <execution>
-#endif
-
 namespace sofa::component::mapping
 {
 
@@ -87,7 +73,9 @@ AdaptiveBeamMapping<TIn,TOut>::AdaptiveBeamMapping(State< In >* from, State< Out
     , d_inputMapName(initData(&d_inputMapName,"nameOfInputMap", "if contactDuplicate==true, it provides the name of the input mapping"))
     , d_nbPointsPerBeam(initData(&d_nbPointsPerBeam, 0.0, "nbPointsPerBeam", "if non zero, we will adapt the points depending on the discretization, with this num of points per beam (compatible with useCurvAbs)"))
     , d_segmentsCurvAbs(initData(&d_segmentsCurvAbs, "segmentsCurvAbs", "the abscissa of each point on the collision model", true, true))
+#if HAS_SUPPORT_STL_PARALLELISM
     , d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation of apply/applyJ"))
+#endif // HAS_SUPPORT_STL_PARALLELISM
     , l_adaptativebeamInterpolation(initLink("interpolation", "Path to the Interpolation component on scene"), interpolation)
     , m_inputMapping(nullptr)
     , m_isSubMapping(isSubMapping)
@@ -108,13 +96,6 @@ void AdaptiveBeamMapping< TIn, TOut>::init()
 
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
     }
-#if not HAS_SUPPORT_STL_PARALLELISM
-    if (d_parallelMapping.getValue())
-    {
-        msg_warning() << "Your compiler does not support STL parallelism, disabling parallel features.";
-        d_parallelMapping.setValue(false);
-    }
-#endif
 }
 
 

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -657,10 +657,11 @@ void AdaptiveBeamMapping< TIn, TOut>::computeDistribution()
         else
         {
             m_pointBeamDistribution.reserve(points.size());
+            const bool printLog = this->f_printLog.getValue();
             for (unsigned int i=0; i<points.size(); i++)
             {
                 const unsigned int beamId = (int)floor(points[i][0]);
-                msg_warning_when(this->f_printLog.getValue() && (beamId > numBeams-1)) << "Points[" << i << "][0] = " << beamId << " is defined outside of the beam length";
+                msg_warning_when(printLog && (beamId > numBeams-1)) << "Points[" << i << "][0] = " << beamId << " is defined outside of the beam length";
                 m_pointBeamDistribution.emplace_back( beamId, Vec3{ points[i][0] - floor(points[i][0]), points[i][1], points[i][2]});
             }
         }

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.h
@@ -89,6 +89,7 @@ public:
 public:
     Data<bool> useCurvAbs;
     Data< type::vector< std::string > > m_controlerPath;
+    Data< bool > d_parallelMapping;
 
     MultiAdaptiveBeamMapping(core::State< In >* from, core::State< Out >* to, TInterventionalRadiologyController* _ircontroller);
     MultiAdaptiveBeamMapping();
@@ -134,7 +135,7 @@ public:
 
 protected:
 
-    sofa::core::topology::TopologyContainer* _topology;
+    sofa::core::topology::TopologyContainer* _topology{ nullptr };
 
     void assignSubMappingFromControllerInfo();
 
@@ -142,7 +143,7 @@ protected:
     sofa::type::vector< sofa::component::fem::WireBeamInterpolation<TIn>  *> m_instrumentList;
     sofa::type::vector<  typename AdaptiveBeamMapping<TIn, TOut>::SPtr > m_subMappingList;
     TInterventionalRadiologyController* m_ircontroller;
-    sofa::component::topology::container::dynamic::EdgeSetTopologyModifier* _edgeMod;
+    sofa::component::topology::container::dynamic::EdgeSetTopologyModifier* _edgeMod{nullptr};
     sofa::type::vector<InReal> _xPointList;     //=> for each mapped point provides the local position (curv. abs.)
     sofa::type::vector<int> _idm_instrumentList; //=> for each mapped point provides the interpolation (in m_instrumentList)
     bool isBarycentricMapping;

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.h
@@ -89,7 +89,9 @@ public:
 public:
     Data<bool> useCurvAbs;
     Data< type::vector< std::string > > m_controlerPath;
-    Data< bool > d_parallelMapping;
+#if HAS_SUPPORT_STL_PARALLELISM
+    Data<bool> d_parallelMapping;           /*!< flag to enable parallel internal computation of apply/applyJ for the submapping(s) AdaptiveBeamMapping */
+#endif // HAS_SUPPORT_STL_PARALLELISM
 
     MultiAdaptiveBeamMapping(core::State< In >* from, core::State< Out >* to, TInterventionalRadiologyController* _ircontroller);
     MultiAdaptiveBeamMapping();

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.h
@@ -89,9 +89,7 @@ public:
 public:
     Data<bool> useCurvAbs;
     Data< type::vector< std::string > > m_controlerPath;
-#if HAS_SUPPORT_STL_PARALLELISM
     Data<bool> d_parallelMapping;           /*!< flag to enable parallel internal computation of apply/applyJ for the submapping(s) AdaptiveBeamMapping */
-#endif // HAS_SUPPORT_STL_PARALLELISM
 
     MultiAdaptiveBeamMapping(core::State< In >* from, core::State< Out >* to, TInterventionalRadiologyController* _ircontroller);
     MultiAdaptiveBeamMapping();

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
@@ -50,9 +50,7 @@ MultiAdaptiveBeamMapping< TIn, TOut>::MultiAdaptiveBeamMapping(core::State< In >
 : Inherit(from, to)
 , useCurvAbs(initData(&useCurvAbs,true,"useCurvAbs","true if the curvilinear abscissa of the points remains the same during the simulation if not the curvilinear abscissa moves with adaptivity and the num of segment per beam is always the same"))
 , m_controlerPath(initData(&m_controlerPath,"ircontroller", "Path to the ircontroller component on scene"))
-#if HAS_SUPPORT_STL_PARALLELISM
 , d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation of apply/applyJ in all the submappings"))
-#endif // HAS_SUPPORT_STL_PARALLELISM
 , m_ircontroller(_ircontroller)
 , isBarycentricMapping(false)
 {
@@ -65,9 +63,7 @@ MultiAdaptiveBeamMapping< TIn, TOut>::MultiAdaptiveBeamMapping()
 : Inherit()
 , useCurvAbs(initData(&useCurvAbs,true,"useCurvAbs","true if the curvilinear abscissa of the points remains the same during the simulation if not the curvilinear abscissa moves with adaptivity and the num of segment per beam is always the same"))
 , m_controlerPath(initData(&m_controlerPath,"ircontroller", "Path to the ircontroller component on scene"))
-#if HAS_SUPPORT_STL_PARALLELISM
 , d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation of apply/applyJ in all the submappings"))
-#endif // HAS_SUPPORT_STL_PARALLELISM
 , m_ircontroller(nullptr)
 , isBarycentricMapping(false)
 {

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
@@ -282,6 +282,7 @@ void MultiAdaptiveBeamMapping< TIn, TOut>::init()
     {
         typename AdaptiveBeamMapping< TIn, TOut>::SPtr newMapping = sofa::core::objectmodel::New<AdaptiveBeamMapping< TIn, TOut>>(this->fromModel, this->toModel,m_instrumentList[i],true);
         newMapping->d_parallelMapping.setParent(&d_parallelMapping);
+        newMapping->d_parallelMapping.update();
         m_subMappingList.push_back(newMapping);
     }
 

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
@@ -50,7 +50,7 @@ MultiAdaptiveBeamMapping< TIn, TOut>::MultiAdaptiveBeamMapping(core::State< In >
 : Inherit(from, to)
 , useCurvAbs(initData(&useCurvAbs,true,"useCurvAbs","true if the curvilinear abscissa of the points remains the same during the simulation if not the curvilinear abscissa moves with adaptivity and the num of segment per beam is always the same"))
 , m_controlerPath(initData(&m_controlerPath,"ircontroller", "Path to the ircontroller component on scene"))
-, d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation of apply/applyJ in all the submappings"))
+, d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation in all the submappings"))
 , m_ircontroller(_ircontroller)
 , isBarycentricMapping(false)
 {
@@ -63,7 +63,7 @@ MultiAdaptiveBeamMapping< TIn, TOut>::MultiAdaptiveBeamMapping()
 : Inherit()
 , useCurvAbs(initData(&useCurvAbs,true,"useCurvAbs","true if the curvilinear abscissa of the points remains the same during the simulation if not the curvilinear abscissa moves with adaptivity and the num of segment per beam is always the same"))
 , m_controlerPath(initData(&m_controlerPath,"ircontroller", "Path to the ircontroller component on scene"))
-, d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation of apply/applyJ in all the submappings"))
+, d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation in all the submappings"))
 , m_ircontroller(nullptr)
 , isBarycentricMapping(false)
 {

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
@@ -50,7 +50,9 @@ MultiAdaptiveBeamMapping< TIn, TOut>::MultiAdaptiveBeamMapping(core::State< In >
 : Inherit(from, to)
 , useCurvAbs(initData(&useCurvAbs,true,"useCurvAbs","true if the curvilinear abscissa of the points remains the same during the simulation if not the curvilinear abscissa moves with adaptivity and the num of segment per beam is always the same"))
 , m_controlerPath(initData(&m_controlerPath,"ircontroller", "Path to the ircontroller component on scene"))
+#if HAS_SUPPORT_STL_PARALLELISM
 , d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation of apply/applyJ in all the submappings"))
+#endif // HAS_SUPPORT_STL_PARALLELISM
 , m_ircontroller(_ircontroller)
 , isBarycentricMapping(false)
 {
@@ -63,7 +65,9 @@ MultiAdaptiveBeamMapping< TIn, TOut>::MultiAdaptiveBeamMapping()
 : Inherit()
 , useCurvAbs(initData(&useCurvAbs,true,"useCurvAbs","true if the curvilinear abscissa of the points remains the same during the simulation if not the curvilinear abscissa moves with adaptivity and the num of segment per beam is always the same"))
 , m_controlerPath(initData(&m_controlerPath,"ircontroller", "Path to the ircontroller component on scene"))
+#if HAS_SUPPORT_STL_PARALLELISM
 , d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation of apply/applyJ in all the submappings"))
+#endif // HAS_SUPPORT_STL_PARALLELISM
 , m_ircontroller(nullptr)
 , isBarycentricMapping(false)
 {

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
@@ -50,6 +50,7 @@ MultiAdaptiveBeamMapping< TIn, TOut>::MultiAdaptiveBeamMapping(core::State< In >
 : Inherit(from, to)
 , useCurvAbs(initData(&useCurvAbs,true,"useCurvAbs","true if the curvilinear abscissa of the points remains the same during the simulation if not the curvilinear abscissa moves with adaptivity and the num of segment per beam is always the same"))
 , m_controlerPath(initData(&m_controlerPath,"ircontroller", "Path to the ircontroller component on scene"))
+, d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation of apply/applyJ in all the submappings"))
 , m_ircontroller(_ircontroller)
 , isBarycentricMapping(false)
 {
@@ -62,6 +63,7 @@ MultiAdaptiveBeamMapping< TIn, TOut>::MultiAdaptiveBeamMapping()
 : Inherit()
 , useCurvAbs(initData(&useCurvAbs,true,"useCurvAbs","true if the curvilinear abscissa of the points remains the same during the simulation if not the curvilinear abscissa moves with adaptivity and the num of segment per beam is always the same"))
 , m_controlerPath(initData(&m_controlerPath,"ircontroller", "Path to the ircontroller component on scene"))
+, d_parallelMapping(initData(&d_parallelMapping, false, "parallelMapping", "flag to enable parallel internal computation of apply/applyJ in all the submappings"))
 , m_ircontroller(nullptr)
 , isBarycentricMapping(false)
 {
@@ -279,6 +281,7 @@ void MultiAdaptiveBeamMapping< TIn, TOut>::init()
     for (unsigned int i=0; i<m_instrumentList.size(); i++)
     {
         typename AdaptiveBeamMapping< TIn, TOut>::SPtr newMapping = sofa::core::objectmodel::New<AdaptiveBeamMapping< TIn, TOut>>(this->fromModel, this->toModel,m_instrumentList[i],true);
+        newMapping->d_parallelMapping.setParent(&d_parallelMapping);
         m_subMappingList.push_back(newMapping);
     }
 


### PR DESCRIPTION
- lots of cleanups here and there (ref, etc)

More importantly, add an optional feature: parallelize computations of apply and applyJ, using built-in parallel loop of STL.
On my bench scene (3instru_collis) it leads to a not-so-negligible gain of 5~10% gain of fps.

By default the option is false, in case of. (I cannot prove it wont lead to nonpredictable side-effects)