### PR TITLE
Update AdaptiveBeamForceFieldAndMass to use a single gravity vector

### DIFF
--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
@@ -191,21 +191,18 @@ public:
     Data<Real> d_massDensity;               ///< Density of the mass (usually in kg/m^3)
     Data<bool> d_useShearStressComputation; ///< if false, suppress the shear stress in the computation
     Data<bool> d_reinforceLength;           ///< if true, perform a separate computation to evaluate the elongation
-    DataVecDeriv d_dataG;
 
 protected :
-
     SingleLink<AdaptiveBeamForceFieldAndMass<DataTypes>, BInterpolation, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_interpolation;
     SingleLink<AdaptiveBeamForceFieldAndMass<DataTypes>, WireRestShape, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_instrumentParameters;
 
-    void applyMassLarge( VecDeriv& df, const VecDeriv& dx, int bIndex, Index nd0Id, Index nd1Id, const double &factor);
+    void applyMassLarge( VecDeriv& df, int bIndex, Index nd0Id, Index nd1Id, const double &factor);
     void applyStiffnessLarge( VecDeriv& df, const VecDeriv& dx, int beam, Index nd0Id, Index nd1Id, const double &factor );
     void computeGravityVector();
 
-    Vec3 m_gravity;
-    type::vector<BeamLocalMatrices> m_localBeamMatrices;
-
 private:
+    type::vector<BeamLocalMatrices> m_localBeamMatrices;
+    Vec6 m_gravity;
 
     void drawElement(const VisualParams* vparams, int beam,
                      Transform &global_H0_local, Transform &global_H1_local) ;

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
@@ -61,8 +61,6 @@ AdaptiveBeamForceFieldAndMass<DataTypes>::AdaptiveBeamForceFieldAndMass()
     , d_massDensity(initData(&d_massDensity,(Real)1.0,"massDensity", "Density of the mass (usually in kg/m^3)" ))
     , d_useShearStressComputation(initData(&d_useShearStressComputation, true, "shearStressComputation","if false, suppress the shear stress in the computation"))
     , d_reinforceLength(initData(&d_reinforceLength, false, "reinforceLength", "if true, a separate computation for the error in elongation is peformed"))
-    , d_dataG(initData(&d_dataG,"dataG","Gravity 3d vector"))
-
     , l_interpolation(initLink("interpolation","Path to the Interpolation component on scene"))
     , l_instrumentParameters(initLink("instrumentParameters", "link to an object specifying physical parameters based on abscissa"))
 {
@@ -96,29 +94,8 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::reinit()
 template <class DataTypes>
 void AdaptiveBeamForceFieldAndMass<DataTypes>::computeGravityVector()
 {
-    Vec3 gravity = this->getContext()->getGravity();
-
-    auto _G = sofa::helper::getWriteOnlyAccessor(d_dataG);
-    _G.resize(l_interpolation->getStateSize());
-
-    m_gravity = Vec3(gravity[0],gravity[1],gravity[2]);
-
-    if(_G.size()==0)
-    {
-        dmsg_warning() << "_G.size = 0";
-        return;
-    }
-
-    for (unsigned int i=0; i<_G.size(); i++)
-    {
-        _G[i][0]=gravity[0];
-        _G[i][1]=gravity[1];
-        _G[i][2]=gravity[2];
-
-        _G[i][3]=(Real)0.0;
-        _G[i][4]=(Real)0.0;
-        _G[i][5]=(Real)0.0;
-    }
+    const Vec3& gravity = getContext()->getGravity();
+    m_gravity = Vec6(gravity[0], gravity[1], gravity[2], 0, 0, 0);
 }
 
 
@@ -291,30 +268,21 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::applyStiffnessLarge( VecDeriv& df
 
 
 template<class DataTypes>
-void AdaptiveBeamForceFieldAndMass<DataTypes>::applyMassLarge( VecDeriv& df, const VecDeriv& dx,
-                                                               int bIndex, Index nd0Id, Index nd1Id,
-                                                               const double &factor)
+void AdaptiveBeamForceFieldAndMass<DataTypes>::applyMassLarge( VecDeriv& df, int bIndex, Index nd0Id, Index nd1Id, const double &factor)
 {
-    Vec6 A0, A1, a0, a1, f0, f1, F0, F1;
-    BeamLocalMatrices &beamLocalMatrix = m_localBeamMatrices[bIndex];
+    const BeamLocalMatrices &beamLocalMatrix = m_localBeamMatrices[bIndex];
 
-    for (unsigned int i=0; i<6; i++)
-    {
-        A0[i] = dx[nd0Id][i];
-        A1[i] = dx[nd1Id][i];
-    }
-
-    /// displacement in local frame
-    a0 = beamLocalMatrix.m_A0Ref*A0;
-    a1 = beamLocalMatrix.m_A1Ref*A1;
+    /// displacement in local frame (only gravity as external force)
+    Vec6 a0 = beamLocalMatrix.m_A0Ref * m_gravity;
+    Vec6 a1 = beamLocalMatrix.m_A1Ref * m_gravity;
 
     /// internal force in local frame
-    f0 = beamLocalMatrix.m_M00*a0 + beamLocalMatrix.m_M01*a1;
-    f1 = beamLocalMatrix.m_M10*a0 + beamLocalMatrix.m_M11*a1;
+    Vec6 f0 = beamLocalMatrix.m_M00*a0 + beamLocalMatrix.m_M01*a1;
+    Vec6 f1 = beamLocalMatrix.m_M10*a0 + beamLocalMatrix.m_M11*a1;
 
     /// force in global frame
-    F0 = beamLocalMatrix.m_A0Ref.multTranspose(f0);
-    F1 = beamLocalMatrix.m_A1Ref.multTranspose(f1);
+    Vec6 F0 = beamLocalMatrix.m_A0Ref.multTranspose(f0);
+    Vec6 F1 = beamLocalMatrix.m_A1Ref.multTranspose(f1);
 
     /// put the result in df
     for (unsigned int i=0; i<6; i++)
@@ -334,21 +302,21 @@ template<class DataTypes>
 void AdaptiveBeamForceFieldAndMass<DataTypes>::addMDx(const MechanicalParams* mparams , DataVecDeriv& dataf, const DataVecDeriv& datadx, double factor)
 {
     SOFA_UNUSED(mparams);
+    SOFA_UNUSED(datadx);
 
     auto f = sofa::helper::getWriteOnlyAccessor(dataf);
-    const VecDeriv& dx = datadx.getValue();
+
+    auto size = l_interpolation->getStateSize();
+    if (f.size() != size)
+        f.resize(size);
 
     unsigned int numBeams = l_interpolation->getNumBeams();
-
-    if (f.size()!=dx.size())
-        f.resize(dx.size()); // current content of the vector will remain the same (http://www.cplusplus.com/reference/vector/vector/resize/)
-
     for (unsigned int b=0; b<numBeams; b++)
     {
         unsigned int node0Idx, node1Idx;
         l_interpolation->getNodeIndices( b,  node0Idx, node1Idx );
 
-        applyMassLarge( f.wref(), dx, b, node0Idx, node1Idx, factor);
+        applyMassLarge( f.wref(), b, node0Idx, node1Idx, factor);
     }
 }
 
@@ -644,8 +612,9 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::addForce (const MechanicalParams*
 
     if(d_computeMass.getValue())
     {
-        /// add gravity:
-        addMDx(mparams, dataf, d_dataG, 1.0);
+        /// will add gravity directly using m_gravity:
+        DataVecDeriv emptyVec;
+        addMDx(mparams, dataf, emptyVec, 1.0);
     }
 }
 


### PR DESCRIPTION
Use a single Vec3 for gravity vector (which is still updated at each timestep using root->getGravity())
instead of filling a DataVecDeriv (aka a vec<Vec6> of the size of the nbr of dof) filled with the same gravity for each dof.

Update all methods to use this single vec3 