### PR TITLE
[WireRestShape] Remove unnecessary use of Edge2QuatTopologyMapping

### DIFF
--- a/src/BeamAdapter/component/engine/WireRestShape.h
+++ b/src/BeamAdapter/component/engine/WireRestShape.h
@@ -180,9 +180,6 @@ private:
      SingleLink<WireRestShape<DataTypes>, MeshLoader, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_loader;     
      /// Pointer to the MeshLoader, should be set using @sa l_loader, otherwise will search for one in current Node.
      MeshLoader* loader{ nullptr };
-
-     /// Link to a Edge2QuadTopologicalMapping, usually used for beam surface rendering to be set to propagate topological changes
-     SingleLink<WireRestShape<DataTypes>, Edge2QuadTopologicalMapping, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_edge2QuadMapping;
 };
 
 

--- a/src/BeamAdapter/component/engine/WireRestShape.h
+++ b/src/BeamAdapter/component/engine/WireRestShape.h
@@ -183,9 +183,6 @@ private:
 
      /// Link to a Edge2QuadTopologicalMapping, usually used for beam surface rendering to be set to propagate topological changes
      SingleLink<WireRestShape<DataTypes>, Edge2QuadTopologicalMapping, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_edge2QuadMapping;
-     /// Pointer to a Edge2QuadTopologicalMapping usually used for beam surface rendering. To be set using @sa l_edge2QuadMapping
-     Edge2QuadTopologicalMapping* edge2QuadMap{ nullptr };
-
 };
 
 

--- a/src/BeamAdapter/component/engine/WireRestShape.inl
+++ b/src/BeamAdapter/component/engine/WireRestShape.inl
@@ -83,7 +83,6 @@ WireRestShape<DataTypes>::WireRestShape() :
   , d_drawRestShape(initData(&d_drawRestShape, (bool)false, "draw", "draw rest shape"))
   , l_topology(initLink("topology", "link to the topology container"))
   , l_loader(initLink("loader", "link to the MeshLoader"))
-  , l_edge2QuadMapping(initLink("edge2QuadMapping", "link to the edge2QuadMapping to render this beam"))
 {
     d_spireDiameter.setGroup("Procedural");
     d_spireHeight.setGroup("Procedural");

--- a/src/BeamAdapter/component/engine/WireRestShape.inl
+++ b/src/BeamAdapter/component/engine/WireRestShape.inl
@@ -211,16 +211,6 @@ void WireRestShape<DataTypes>::init()
     for (int i=0; i<d_numEdges.getValue(); i++)
         _topology->addEdge(i,i+1);
     
-    /// Get possible edge2Quad Mapping if one set. 
-    // TODO epernod 2022-08-05: check if the pointer to the mapping is still useful. Only used in releaseWirePart which should be now automatically handle by Topological changes mechanism.
-    edge2QuadMap = l_edge2QuadMapping.get();
-
-    const TagSet& tags = this->getTags();
-    if (!tags.empty())
-    {
-        msg_warning() << "Using tags to find edge2QuadMapping has been depreciate. Please use 'edge2QuadMapping' link to set the path to the correct topological mapping.";
-    }
-
 
     ////////////////////////////////////////////////////////
     ////////// keyPoint list and Density Assignement ///////
@@ -317,19 +307,7 @@ void WireRestShape<DataTypes>::releaseWirePart(){
             edgeMod->removeEdges(edge_remove,false); // remove the single edge and do not remove any point...
 
             msg_info() << "WireRestShape _topology name="<<_topology->getName()<<" - numEdges ="<<_topology->getNbEdges() ;
-
-            // propagate the topological change to the topological mapping //
-            if(edge2QuadMap!=nullptr)
-            {
-                edge2QuadMap->updateTopologicalMappingTopDown();
-                sofa::component::topology::container::dynamic::QuadSetTopologyModifier *quadMod;
-                edge2QuadMap->getContext()->get(quadMod);
-                quadMod->notifyEndingEvent();
-            }
-
-
-            _topology->resetTopologyChangeList();
-
+            
             return;
         }
     }


### PR DESCRIPTION
The pointer to the Edge2QuatTopologyMapping mapping is not necessary to manually propagate the topological changes.
The propagation will be done automatically through topology changes pipeline.