### PR TITLE
[InterventionalRadiologyController] Improve init checks to avoid potential crashes

### DIFF
--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -107,6 +107,10 @@ void InterventionalRadiologyController<DataTypes>::init()
         sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
+    else
+    {
+        msg_info() << m_instrumentsList.size() << " instrument(s) found (WireBeamInterpolation)";
+    }
 
      m_activatedPointsBuf.clear();
 

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -201,6 +201,23 @@ void InterventionalRadiologyController<DataTypes>::bwdInit()
         x[i] = d_startingPos.getValue();
     m_numControlledNodes = x.size();
 
+    sofa::Size nbrBeam = 0;
+    for (unsigned int i = 0; i < m_instrumentsList.size(); i++)
+    {
+        type::vector<Real> xP_noticeable_I;
+        type::vector< int > density_I;
+        m_instrumentsList[i]->getSamplingParameters(xP_noticeable_I, density_I);
+
+        for (auto nb : density_I)
+            nbrBeam += nb;
+    }
+
+    if (nbrBeam > m_numControlledNodes)
+    {
+        msg_warning() << "Parameter missmatch: According to the list of controlled instrument controlled. The number of potential beams: "
+            << nbrBeam << " exceed the number of degree of freedom in the MechanicalObject: " << m_numControlledNodes << ". This could lead to unespected behavior.";
+    }
+        
     applyInterventionalRadiologyController();
     reinit();
 }

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -87,7 +87,7 @@ void InterventionalRadiologyController<DataTypes>::init()
     const type::vector<std::string>& instrumentPathList = d_instrumentsPath.getValue();
     if (instrumentPathList.empty())
     {
-        getContext()->template get<WBeamInterpolation>(&m_instrumentsList, sofa::core::objectmodel::BaseContext::SearchRoot);
+        getContext()->template get<WBeamInterpolation>(&m_instrumentsList, sofa::core::objectmodel::BaseContext::Local);
     }
     else
     {

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -88,8 +88,7 @@ void InterventionalRadiologyController<DataTypes>::init()
     const type::vector<std::string>& instrumentPathList = d_instrumentsPath.getValue();
     if (instrumentPathList.empty())
     {
-        WBeamInterpolation * wbinterpol= context->get< WBeamInterpolation >(BaseContext::Local);
-        m_instrumentsList.push_back(wbinterpol);
+        getContext()->get<WBeamInterpolation>(&m_instrumentsList, sofa::core::objectmodel::BaseContext::SearchRoot);
     }
     else
     {
@@ -104,8 +103,11 @@ void InterventionalRadiologyController<DataTypes>::init()
         }
     }
 
-    if(m_instrumentsList.empty())
-        msg_error()<<"No Beam Interpolation found !!! the component can not work.";
+    if (m_instrumentsList.empty()) {
+        msg_error() << "No instrument found (no WireBeamInterpolation)! the component can not work and will be set to Invalid.";
+        sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
+    }
 
      m_activatedPointsBuf.clear();
 
@@ -121,11 +123,6 @@ void InterventionalRadiologyController<DataTypes>::init()
         loadMotionData(d_motionFilename.getValue());
     }
 
-    if (m_instrumentsList.size() == 0)
-    {
-        msg_error()<<"No instrument found ( no WireBeamInterpolation).";
-        return;
-    }
     auto x_instr_tip = sofa::helper::getWriteOnlyAccessor(d_xTip);
     x_instr_tip.resize(m_instrumentsList.size());
 
@@ -161,7 +158,7 @@ void InterventionalRadiologyController<DataTypes>::init()
 
     Inherit::init();
 
-    reinit();
+    sofa::core::objectmodel::BaseObject::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 template<class DataTypes>

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -87,7 +87,7 @@ void InterventionalRadiologyController<DataTypes>::init()
     const type::vector<std::string>& instrumentPathList = d_instrumentsPath.getValue();
     if (instrumentPathList.empty())
     {
-        getContext()->get<WBeamInterpolation>(&m_instrumentsList, sofa::core::objectmodel::BaseContext::SearchRoot);
+        getContext()->template get<WBeamInterpolation>(&m_instrumentsList, sofa::core::objectmodel::BaseContext::SearchRoot);
     }
     else
     {


### PR DESCRIPTION
- If no instrument is given as input, the init method was searching for a single instrument using GetContext. 
```
WBeamInterpolation * wbinterpol= context->get< WBeamInterpolation >(BaseContext::Local);
m_instrumentsList.push_back(wbinterpol);
```
The pointer was not tested so if no instrument were present in the scene, the IRCtrl was initialised with a null pointer. 
Change this method to directly fill the vector with all corresponding component found.

- Add a warning at init if the number of dof inside the current mechanicalObject is really low compare to the number of beam that can be deployed in the scene. this doesn't really fix #70 but at least warn user. 