### PR TITLE
Remove dependency on Sofa.GL

### DIFF
--- a/BeamAdapterConfig.cmake.in
+++ b/BeamAdapterConfig.cmake.in
@@ -7,7 +7,6 @@ set(BEAMADAPTER_HAVE_SOFADVANCEDCONSTRAINT @BEAMADAPTER_HAVE_SOFADVANCEDCONSTRAI
 set(BEAMADAPTER_HAVE_SOFACUDA @BEAMADAPTER_HAVE_SOFACUDA@)
 
 find_package(Sofa.Simulation.Core QUIET REQUIRED)
-find_package(Sofa.GL QUIET REQUIRED)
 find_package(Sofa.Component.StateContainer QUIET REQUIRED)
 find_package(Sofa.Component.Controller QUIET REQUIRED)
 find_package(Sofa.Component.Topology.Container.Dynamic QUIET REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ include(cmake/environment.cmake)
 
 find_package(Sofa.Simulation.Core REQUIRED)
 
-sofa_find_package(Sofa.GL REQUIRED)
 sofa_find_package(Sofa.Component.StateContainer REQUIRED)
 sofa_find_package(Sofa.Component.Controller REQUIRED)
 sofa_find_package(Sofa.Component.Topology.Container.Dynamic REQUIRED)
@@ -125,7 +124,7 @@ endif()
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${README_FILES})
 
-target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Simulation.Core Sofa.GL)
+target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Simulation.Core)
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component.StateContainer Sofa.Component.Controller Sofa.Component.Topology.Container.Dynamic Sofa.Component.Topology.Mapping)
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Component.Collision.Geometry Sofa.Component.Constraint.Lagrangian Sofa.Component.Constraint.Projective)
 

--- a/src/BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.inl
+++ b/src/BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.inl
@@ -25,7 +25,6 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/type/Vec.h>
 #include <sofa/linearalgebra/BaseVector.h>
-#include <sofa/gl/template.h>
 #include <sofa/helper/visual/DrawTool.h>
 #include <sofa/core/behavior/ConstraintResolution.h>
 #include <BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.h>

--- a/src/BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.inl
+++ b/src/BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.inl
@@ -23,7 +23,6 @@
 
 //////////////////////// Inclusion of headers...from wider to narrower/closer //////////////////////
 #include <sofa/core/visual/VisualParams.h>
-#include <sofa/gl/template.h>
 
 #include <BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.h>
 #include <sofa/core/behavior/ConstraintResolution.h>

--- a/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.inl
@@ -44,9 +44,7 @@
 #include <sofa/defaulttype/RigidTypes.h>
 #include <sofa/helper/OptionsGroup.h>
 
-#include <sofa/gl/Cylinder.h>
 #include <sofa/simulation/Simulation.h>
-#include <sofa/gl/Axis.h>
 #include <sofa/core/visual/VisualParams.h>
 
 


### PR DESCRIPTION
Actually nothing was using OpenGL in BeamAdapter, only remnant headers from sofa.gl was keeping the hard dependency in the CMake files.