### PR TITLE
Remove useless Sofa.GL include

### DIFF
--- a/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.h
+++ b/src/BeamAdapter/component/constraint/ImplicitSurfaceAdaptiveConstraint.h
@@ -22,7 +22,6 @@
 #include <sofa/core/behavior/BaseInteractionConstraint.h>
 #include <sofa/core/behavior/PairInteractionConstraint.h>
 #include <sofa/core/behavior/MechanicalState.h>
-#include <sofa/gl/template.h>
 
 #include <sofa/type/Mat.h>
 #include <sofa/type/Vec.h>


### PR DESCRIPTION
Compilation failed due to https://github.com/sofa-framework/BeamAdapter/pull/75