### PR TITLE
[InterventionalRadiologyController] Revert sampling change of behaviour

### DIFF
--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -557,8 +557,6 @@ void InterventionalRadiologyController<DataTypes>::interventionalRadiologyComput
                     newCurvAbs.push_back(value);
                 }
 
-                // Add j+1 bound point
-                newCurvAbs.push_back(curvAbs_nxP);
                 xSampling = curvAbs_nxP;
             }
         }

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -536,6 +536,10 @@ void InterventionalRadiologyController<DataTypes>::interventionalRadiologyComput
             //compute the corresponding abs curv of this "noticeable point" on the combined intrument
             const Real curvAbs_xP = xBegin[i] + xP;
             const Real curvAbs_nxP = xBegin[i] + nxP;
+
+            // In any case, the key points are added as soon as they are deployed
+            if (curvAbs_xP > 0)
+                newCurvAbs.push_back(curvAbs_xP);
             
             // compute interval between next point and previous one (0 for the first iter)
             const Real curvAbs_interval = (curvAbs_nxP - xSampling);
@@ -558,6 +562,13 @@ void InterventionalRadiologyController<DataTypes>::interventionalRadiologyComput
                 xSampling = curvAbs_nxP;
             }
         }
+
+        // After the end of the for loop above, we just have to process the
+        // instrument last key point
+        const Real lastxP = xP_noticeable_I[xP_noticeable_I.size()-1];
+        const Real curvAbs_lastxP = xBegin[i] + lastxP;
+        if (curvAbs_lastxP > 0)
+            newCurvAbs.push_back(curvAbs_lastxP);
     }
 
 


### PR DESCRIPTION
This PR addresses issue #87.

As explained in the issue, the new implementation doesn't automatically include in the sampling the key points of the instruments. Specifically, these key points are ignored if the instrument is deployed, but is not visible (i.e. if another instrument with a wider diameter is deployed further).

The implementation suggested here always adds the key points in the list of new curvilinear abscissas, and actually does a sampling on the visible instruments. This should be the same as the original behaviour
NB: I am not sure if the first key point of the interval is also taken into account in the sampling loop, or not. This shouldn't have any influence on the outcome, as the new curvilinear abscissas are sorted afterwards (with duplicated nodes removed), but if the key point is counted twice, we should change the conditions of the loop to do one iteration less.

Below are two videos showing the change of behaviour on the example scene `3instruments.scn`:
Before the PR :

https://user-images.githubusercontent.com/34058933/216340491-66d8017f-c35a-406a-8184-b8ba17182aa0.mp4

After the PR:

https://user-images.githubusercontent.com/34058933/216340616-2270d45b-8df8-4f11-81f6-c64f8a50a148.mp4
