### PR TITLE
[MultiAdaptiveBeamMapping] Fix memory leak

### DIFF
--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.h
@@ -140,7 +140,7 @@ protected:
 
     // for fromSeveralInterpolations option
     sofa::type::vector< sofa::component::fem::WireBeamInterpolation<TIn>  *> m_instrumentList;
-    sofa::type::vector<  AdaptiveBeamMapping<TIn, TOut>* > m_subMappingList;
+    sofa::type::vector<  typename AdaptiveBeamMapping<TIn, TOut>::SPtr > m_subMappingList;
     TInterventionalRadiologyController* m_ircontroller;
     sofa::component::topology::container::dynamic::EdgeSetTopologyModifier* _edgeMod;
     sofa::type::vector<InReal> _xPointList;     //=> for each mapped point provides the local position (curv. abs.)

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
@@ -274,7 +274,7 @@ void MultiAdaptiveBeamMapping< TIn, TOut>::init()
         m_subMappingList.clear();
         for (unsigned int i=0; i<m_instrumentList.size(); i++)
         {
-                AdaptiveBeamMapping< TIn, TOut>* newMapping = new AdaptiveBeamMapping< TIn, TOut>(this->fromModel, this->toModel,m_instrumentList[i],true);
+                typename AdaptiveBeamMapping< TIn, TOut>::SPtr newMapping = sofa::core::objectmodel::New<AdaptiveBeamMapping< TIn, TOut>>(this->fromModel, this->toModel,m_instrumentList[i],true);
                 m_subMappingList.push_back(newMapping);
         }
 


### PR DESCRIPTION
Using SPtr.

Not only because the created AdaptiveBeamMapping were never deleted, but also there are storing a BeamInterpolation::SPtr. Thus, these BeamInterpolation objects were never deleted as well (as the ref count is not 0, kept by the mapping)

`3instruments_collis.scn -g batch -n 5000`
Before: `SUMMARY: AddressSanitizer: 612711 byte(s) leaked in 4084 allocation(s).`
After:  `SUMMARY: AddressSanitizer: 1482 byte(s) leaked in 14 allocation(s)`

(using https://github.com/sofa-framework/sofa/pull/3671 for the SOFA branch)