### PR TITLE
Use d_componentState

### DIFF
--- a/src/BeamAdapter/component/WireBeamInterpolation.h
+++ b/src/BeamAdapter/component/WireBeamInterpolation.h
@@ -169,7 +169,7 @@ public:
     /// Bring inherited attributes and function in the current lookup context.
     /// otherwise any access to the base::attribute would require
     /// the "this->" approach.
-    using  BeamInterpolation<DataTypes>::m_componentstate ;
+    using  BeamInterpolation<DataTypes>::d_componentState ;
     ////////////////////////////////////////////////////////////////////////////
 
 public:


### PR DESCRIPTION
This was using an old compatibility layer to redirect `m_componentstate` to `d_componentstate`