### PR TITLE
[BeamInterpolation] Add method computeTransform with node indices as parameters

### DIFF
--- a/src/BeamAdapter/component/BeamInterpolation.h
+++ b/src/BeamAdapter/component/BeamInterpolation.h
@@ -155,7 +155,10 @@ public:
     void getDOFtoLocalTransformInGlobalFrame(unsigned int edgeInList, Transform &DOF0Global_H_local0, Transform &DOF1Global_H_local1, const VecCoord &x);
 
     
-    int computeTransform(ElementID edgeInList, Transform &global_H_local0,  Transform &global_H_local1, const VecCoord &x);
+    int computeTransform(const ElementID edgeInList, Transform &global_H_local0,  Transform &global_H_local1, const VecCoord &x);
+    int computeTransform(const ElementID edgeInList, const PointID node0Idx, const PointID node1Idx, Transform& global_H_local0, Transform& global_H_local1, const VecCoord& x);
+
+    
 
     void getTangent(Vec3& t, const Real& baryCoord,
                     const Transform &global_H_local0, const Transform &global_H_local1,const Real &L);

--- a/src/BeamAdapter/component/BeamInterpolation.h
+++ b/src/BeamAdapter/component/BeamInterpolation.h
@@ -89,6 +89,7 @@ public:
     using Transform = typename sofa::defaulttype::SolidTypes<Real>::Transform;
     using SpatialVector = typename sofa::defaulttype::SolidTypes<Real>::SpatialVector;
 
+    using PointID = BaseMeshTopology::PointID;
     using ElementID = BaseMeshTopology::EdgeID;
     using VecElementID = type::vector<BaseMeshTopology::EdgeID>;
     using VecEdges = type::vector<BaseMeshTopology::Edge>;

--- a/src/BeamAdapter/component/BeamInterpolation.inl
+++ b/src/BeamAdapter/component/BeamInterpolation.inl
@@ -315,7 +315,7 @@ void BeamInterpolation<DataTypes>::bwdInit()
                 // this transforamtion is given by global_H_local0 for node 0 (and dof0)
                 // and global_H_local1 for node 1 (and dof1)
                 Transform global_H_local0, global_H_local1;
-                computeTransform(i,  global_H_local0,  global_H_local1, statePos.ref()) ;
+                computeTransform(i, nd0Id, nd1Id, global_H_local0, global_H_local1, statePos.ref());
                 Vec3 beam_segment = global_H_local1.getOrigin() -  global_H_local0.getOrigin();
                 lengthList.push_back(beam_segment.norm());
 
@@ -641,7 +641,7 @@ void BeamInterpolation<DataTypes>::getDOFtoLocalTransformInGlobalFrame(unsigned 
 
 
 template<class DataTypes>
-int BeamInterpolation<DataTypes>::computeTransform(ElementID edgeInList,
+int BeamInterpolation<DataTypes>::computeTransform(const ElementID edgeInList,
     Transform &global_H_local0,
     Transform &global_H_local1,
     const VecCoord &x)
@@ -654,16 +654,24 @@ int BeamInterpolation<DataTypes>::computeTransform(ElementID edgeInList,
         return -1;
     }
 
+    return computeTransform(edgeInList, node0Idx, node1Idx, global_H_local0, global_H_local1, x);
+}
+
+
+template<class DataTypes>
+int BeamInterpolation<DataTypes>::computeTransform(const ElementID edgeInList, const PointID node0Idx, const PointID node1Idx, Transform& global_H_local0, Transform& global_H_local1, const VecCoord& x)
+{
+
     /// 2. Computes the optional rigid transformation of DOF0_Transform_node0 and DOF1_Transform_node1
     Transform DOF0_H_local0, DOF1_H_local1;
-    getDOFtoLocalTransform(edgeInList, DOF0_H_local0,  DOF1_H_local1);
+    getDOFtoLocalTransform(edgeInList, DOF0_H_local0, DOF1_H_local1);
 
     /// 3. Computes the transformation global To local for both nodes
-    Transform global_H_DOF0(x[node0Idx].getCenter(),x[node0Idx].getOrientation());
-    Transform global_H_DOF1(x[node1Idx].getCenter(),x[node1Idx].getOrientation());
+    Transform global_H_DOF0(x[node0Idx].getCenter(), x[node0Idx].getOrientation());
+    Transform global_H_DOF1(x[node1Idx].getCenter(), x[node1Idx].getOrientation());
     /// - add a optional transformation
-    global_H_local0 = global_H_DOF0*DOF0_H_local0;
-    global_H_local1 = global_H_DOF1*DOF1_H_local1;
+    global_H_local0 = global_H_DOF0 * DOF0_H_local0;
+    global_H_local1 = global_H_DOF1 * DOF1_H_local1;
 
     return 1; /// no error
 }

--- a/src/BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.inl
+++ b/src/BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.inl
@@ -119,14 +119,15 @@ void AdaptiveBeamLengthConstraint<DataTypes>::detectElongation(const VecCoord& x
         length=(P0-P3).norm();
         rest_length = interpolation->getLength(b);
 
+        unsigned n0, n1;
+        interpolation->getNodeIndices(b, n0, n1);
+
         /// 2. compute the bending angle
         Transform Tnode0, Tnode1;
-        interpolation->computeTransform(b,Tnode0,Tnode1,x);
+        interpolation->computeTransform(b, n0, n1, Tnode0,Tnode1,x);
         Real angleBeam = interpolation->ComputeTotalBendingRotationAngle(rest_length/10.0, Tnode0, Tnode1,rest_length , 0.0, 1.0);
 
         /// 3. treatment of the different case..
-        unsigned n0, n1;
-        interpolation->getNodeIndices(b, n0, n1);
         bool case1a = (n0==n1);
 
         if(prev_stretch)
@@ -164,7 +165,7 @@ void AdaptiveBeamLengthConstraint<DataTypes>::detectElongation(const VecCoord& x
                 interpolation->getSplinePoints(b,xfree,P0,P1,P2,P3);
 
                 Transform global_H_local0_free, global_H_local1_free;
-                interpolation->computeTransform(b,  global_H_local0_free,  global_H_local1_free, xfree);
+                interpolation->computeTransform(b, n0, n1, global_H_local0_free,  global_H_local1_free, xfree);
                 intervalDef.posFreeEnd  = global_H_local0_free.getOrigin(); /// store the free position
 
                 intervalDef.rest_length=rest_length_interval; /// store the rest_length
@@ -231,10 +232,10 @@ void AdaptiveBeamLengthConstraint<DataTypes>::detectElongation(const VecCoord& x
                 interpolation->getDOFtoLocalTransform(b, DOF0_H_local0,  DOF1_H_local1);
 
                 Transform global_H_local0, global_H_local1;
-                interpolation->computeTransform(b,  global_H_local0,  global_H_local1, x);
+                interpolation->computeTransform(b, n0, n1, global_H_local0,  global_H_local1, x);
 
                 Transform global_H_local0_free, global_H_local1_free;
-                interpolation->computeTransform(b,  global_H_local0_free,  global_H_local1_free, xfree);
+                interpolation->computeTransform(b, n0, n1, global_H_local0_free,  global_H_local1_free, xfree);
 
                 intervalDef.dof_H_begin = DOF0_H_local0;
                 intervalDef.IdxBegin = n0;
@@ -262,11 +263,11 @@ void AdaptiveBeamLengthConstraint<DataTypes>::detectElongation(const VecCoord& x
 
         Transform global_H_local0, global_H_local1;
 
-        interpolation->computeTransform(b,  global_H_local0,  global_H_local1, x);
+        interpolation->computeTransform(b, n0, n1, global_H_local0,  global_H_local1, x);
 
 
         Transform global_H_local0_free, global_H_local1_free;
-        interpolation->computeTransform(b,  global_H_local0_free,  global_H_local1_free, xfree);
+        interpolation->computeTransform(b, n0, n1, global_H_local0_free,  global_H_local1_free, xfree);
 
 
         intervalDef.dof_H_end = DOF1_H_local1;

--- a/src/BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.inl
+++ b/src/BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.inl
@@ -168,9 +168,12 @@ void AdaptiveBeamSlidingConstraint<DataTypes>::buildConstraintMatrix(const Const
             continue;
         }
 
+        unsigned int node0, node1;
+        interpolation->getNodeIndices(beam, node0, node1);
+
         // Position and frame on the curve
         interpolation->getBeamAtCurvAbs(m_previousPositions[i], beam, baryCoord);
-        interpolation->computeTransform(beam, Tnode0, Tnode1, x1free.ref());
+        interpolation->computeTransform(beam, node0, node1, Tnode0, Tnode1, x1free.ref());
         interpolation->InterpolateTransformUsingSpline(Tresult, baryCoord, Tnode0, Tnode1, interpolation->getLength(beam));
         Pos p = Tresult.getOrigin();
         Pos dir0, dir1, dir2;
@@ -186,10 +189,8 @@ void AdaptiveBeamSlidingConstraint<DataTypes>::buildConstraintMatrix(const Const
         m_violations.push_back(violation * dir0);
 
         // Define the constraint
-        unsigned int node0, node1;
         SpatialVector sv0, sv1;
         Vec3 nullRot(0,0,0);
-        interpolation->getNodeIndices(beam, node0, node1);
 
         MatrixDerivRowIterator c1_it = c1.wref().writeLine(m_cid + m_nbConstraints);
         MatrixDerivRowIterator c2_it = c2.wref().writeLine(m_cid + m_nbConstraints);

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
@@ -460,8 +460,8 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::addForce (const MechanicalParams*
     for (unsigned int beamId=0; beamId <numBeams; beamId++)
     {
         ///find the indices of the nodes
-        unsigned int node0Idx, node1Idx;
-        l_interpolation->getNodeIndices(beamId,  node0Idx, node1Idx );
+        sofa::Index node0Idx, node1Idx;
+        l_interpolation->getNodeIndices(beamId, node0Idx, node1Idx);
 
         ///find the beamMatrices:
         BeamLocalMatrices& beamMatrices = m_localBeamMatrices[beamId];
@@ -470,7 +470,7 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::addForce (const MechanicalParams*
         Transform global_H_local0, global_H_local1;
 
         /// 1. get the current transform of the beam:
-        l_interpolation->computeTransform(beamId, global_H_local0, global_H_local1, x);
+        l_interpolation->computeTransform(beamId, node0Idx, node1Idx, global_H_local0, global_H_local1, x);
 
         /// 2. Computes the frame of the beam based on the spline interpolation:
         Transform global_H_local;
@@ -707,9 +707,9 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::draw(const VisualParams *vparams)
     {
         Transform globalH0Local,  globalH1Local;
 
-        l_interpolation->computeTransform(b, globalH0Local, globalH1Local, x.ref());
         unsigned int node0Idx, node1Idx;
-        l_interpolation->getNodeIndices( b,  node0Idx, node1Idx );
+        l_interpolation->getNodeIndices(b, node0Idx, node1Idx);
+        l_interpolation->computeTransform(b, node0Idx, node1Idx, globalH0Local, globalH1Local, x.ref());
 
         if (vparams->displayFlags().getShowBehaviorModels() && node0Idx!=node1Idx)
             drawElement(vparams, b, globalH0Local, globalH1Local);

--- a/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.inl
@@ -547,8 +547,8 @@ void AdaptiveInflatableBeamForceField<DataTypes>::addForce (const MechanicalPara
     for (unsigned int b=0; b<numBeams; b++)
     {
         ///find the indices of the nodes
-        unsigned int node0Idx, node1Idx;
-        l_interpolation->getNodeIndices( b,  node0Idx, node1Idx );
+        sofa::Index node0Idx, node1Idx;
+        l_interpolation->getNodeIndices(b, node0Idx, node1Idx);
 
         ///find the beamMatrices:
         BeamLocalMatrices  *beamMatrices = &m_localBeamMatrices[b]  ;//new BeamLocalMatrices();
@@ -558,7 +558,7 @@ void AdaptiveInflatableBeamForceField<DataTypes>::addForce (const MechanicalPara
 
         /// 1. get the current transform of the beam:
         dmsg_info() << "in addForce";
-        l_interpolation->computeTransform(b, global_H_local0, global_H_local1, x);
+        l_interpolation->computeTransform(b, node0Idx, node1Idx, global_H_local0, global_H_local1, x);
 
         /// 2. Computes the frame of the beam based on the spline interpolation:
         Transform global_H_local;
@@ -768,9 +768,9 @@ void AdaptiveInflatableBeamForceField<DataTypes>::draw(const VisualParams *vpara
     {
         Transform globalH0Local,  globalH1Local;
 
-        l_interpolation->computeTransform(b, globalH0Local, globalH1Local, x.ref());
         unsigned int node0Idx, node1Idx;
-        l_interpolation->getNodeIndices( b,  node0Idx, node1Idx );
+        l_interpolation->getNodeIndices(b, node0Idx, node1Idx);
+        l_interpolation->computeTransform(b, node0Idx, node1Idx, globalH0Local, globalH1Local, x.ref());
 
         if (vparams->displayFlags().getShowBehaviorModels() && node0Idx!=node1Idx)
             drawElement(vparams, b, globalH0Local, globalH1Local);


### PR DESCRIPTION
Add a second method computeTransform with node indices as parameters to avoid multiple call of GetNodeIndices when they are already known