### PR TITLE
Remove code linked to brokenIn2

### DIFF
--- a/src/BeamAdapter/component/BeamInterpolation.h
+++ b/src/BeamAdapter/component/BeamInterpolation.h
@@ -276,9 +276,6 @@ public:
     void addCollisionOnBeam(unsigned int b) ;
     void clearCollisionOnBeam() ;
 
-    /// Vector or links to the Wire section material. The order of the linked material will define the WireShape structure.
-    //Link<BeamInterpolation<DataTypes>, BaseRodSectionMaterial<DataTypes>, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_sectionMaterial;
-
     /////////////////////////// Deprecated Methods  ////////////////////////////////////////// 
     unsigned int getNumBeamsNotUnderControl() { 
         msg_warning() << "Releasing catheter or brokenIn2 mode is not anymore supported. Feature has been removed after release v23.06";

--- a/src/BeamAdapter/component/BeamInterpolation.h
+++ b/src/BeamAdapter/component/BeamInterpolation.h
@@ -139,7 +139,6 @@ public:
     bool verifyTopology();
     void computeCrossSectionInertiaMatrix();
 
-    unsigned int getNumBeamsNotUnderControl(){return this->m_numBeamsNotUnderControl;}
     unsigned int getNumBeams(){return this->d_edgeList.getValue().size();}
 
     void getAbsCurvXFromBeam(int beam, Real& x_curv);
@@ -277,6 +276,15 @@ public:
     void addCollisionOnBeam(unsigned int b) ;
     void clearCollisionOnBeam() ;
 
+    /// Vector or links to the Wire section material. The order of the linked material will define the WireShape structure.
+    //Link<BeamInterpolation<DataTypes>, BaseRodSectionMaterial<DataTypes>, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_sectionMaterial;
+
+    /////////////////////////// Deprecated Methods  ////////////////////////////////////////// 
+    unsigned int getNumBeamsNotUnderControl() { 
+        msg_warning() << "Releasing catheter or brokenIn2 mode is not anymore supported. Feature has been removed after release v23.06";
+        return 0;
+    }
+
 protected :
     /// DATA INPUT (that could change in real-time)
     using StateDataTypes = sofa::defaulttype::StdVectorTypes< sofa::type::Vec<DataTypes::spatial_dimensions, Real>, sofa::type::Vec<DataTypes::spatial_dimensions, Real>, Real >;
@@ -324,8 +332,6 @@ protected :
 
     /// this->brokenInTwo = if true, the wire is in two separate parts
     bool  m_isControlled            {false} ;
-    bool  m_brokenInTwo              {false} ;
-    unsigned int m_numBeamsNotUnderControl {0} ;
 };
 
 #if !defined(SOFA_PLUGIN_BEAMADAPTER_BEAMINTERPOLATION_CPP)

--- a/src/BeamAdapter/component/BeamInterpolation.h
+++ b/src/BeamAdapter/component/BeamInterpolation.h
@@ -277,7 +277,8 @@ public:
     void clearCollisionOnBeam() ;
 
     /////////////////////////// Deprecated Methods  ////////////////////////////////////////// 
-    unsigned int getNumBeamsNotUnderControl() { 
+    [[deprecated("Releasing catheter or brokenIn2 mode is not anymore supported. Feature has been removed after release v23.06")]]
+    unsigned int getNumBeamsNotUnderControl() {
         msg_warning() << "Releasing catheter or brokenIn2 mode is not anymore supported. Feature has been removed after release v23.06";
         return 0;
     }

--- a/src/BeamAdapter/component/BeamInterpolation.inl
+++ b/src/BeamAdapter/component/BeamInterpolation.inl
@@ -135,9 +135,7 @@ BeamInterpolation<DataTypes>::BeamInterpolation() :
   , m_topology(nullptr)
   , m_mstate(nullptr)
 {
-    m_brokenInTwo=false;
     m_isControlled=false;
-    m_numBeamsNotUnderControl = 0;
     m_StateNodes->setName("bezierNodes");
     addSlave(m_StateNodes);
 }
@@ -426,22 +424,11 @@ void BeamInterpolation<DataTypes>::clear()
     auto DOF1TransformNode1 = sofa::helper::getWriteOnlyAccessor(d_DOF1TransformNode1);
     auto curvAbsList = sofa::helper::getWriteOnlyAccessor(d_curvAbsList);
 
-    if(m_brokenInTwo)
-    {
-        edgeList.resize(m_numBeamsNotUnderControl);
-        lengthList.resize(m_numBeamsNotUnderControl);
-        DOF0TransformNode0.resize(m_numBeamsNotUnderControl);
-        DOF1TransformNode1.resize(m_numBeamsNotUnderControl);
-        curvAbsList.resize(m_numBeamsNotUnderControl);
-    }
-    else
-    {
-        edgeList.clear();
-        lengthList.clear();
-        DOF0TransformNode0.clear();
-        DOF1TransformNode1.clear();
-        curvAbsList.clear();
-    }
+    edgeList.clear();
+    lengthList.clear();
+    DOF0TransformNode0.clear();
+    DOF1TransformNode1.clear();
+    curvAbsList.clear();
 }
 
 

--- a/src/BeamAdapter/component/BeamInterpolation.inl
+++ b/src/BeamAdapter/component/BeamInterpolation.inl
@@ -366,8 +366,7 @@ void BeamInterpolation<DataTypes>::reset()
     if(d_componentState.getValue()==ComponentState::Invalid)
         return ;
 
-    bwdInit(); 
-    m_numBeamsNotUnderControl=0;
+    bwdInit();
 }
 
 template<class DataTypes>

--- a/src/BeamAdapter/component/WireBeamInterpolation.h
+++ b/src/BeamAdapter/component/WireBeamInterpolation.h
@@ -183,6 +183,7 @@ public:
 
     /////////////////////////// Deprecated Methods  ////////////////////////////////////////// 
     /// For coils: a part of the coil instrument can be brokenIn2  (by default the point of release is the end of the straight length)
+    [[deprecated("Releasing catheter or brokenIn2 mode is not anymore supported. Feature has been removed after release v23.06")]]
     bool breaksInTwo(const Real& x_min_out, Real& x_break, int& numBeamsNotUnderControlled) {
         SOFA_UNUSED(x_min_out);
         SOFA_UNUSED(x_break);

--- a/src/BeamAdapter/component/WireBeamInterpolation.h
+++ b/src/BeamAdapter/component/WireBeamInterpolation.h
@@ -137,12 +137,11 @@ public:
 
     virtual void getRestTransform(unsigned int edgeInList, Transform &local0_H_local1_rest);
     void getSplineRestTransform(unsigned int edgeInList, Transform &local_H_local0_rest, Transform &local_H_local1_rest) override;
-    void getBeamAtCurvAbs(const Real& x_input, unsigned int &edgeInList_output, Real& baryCoord_output, unsigned int start=0) override;
 
     void getCurvAbsAtBeam(const unsigned int &edgeInList_input, const Real& baryCoord_input, Real& x_output);
     bool getApproximateCurvAbs(const Vec3& x_input, const VecCoord& x,  Real& x_output);	// Project a point on the segments, return false if cant project
 
-    bool breaksInTwo(const Real &x_min_out,  Real &x_break, int &numBeamsNotUnderControlled );
+    
 
     void setPathToRestShape(const std::string &o){m_restShape.setPath(o);}
 
@@ -181,6 +180,16 @@ public:
 
     template<class T>
     static typename T::SPtr  create(T* tObj, core::objectmodel::BaseContext* context, core::objectmodel::BaseObjectDescription* arg) ;
+
+    /////////////////////////// Deprecated Methods  ////////////////////////////////////////// 
+    /// For coils: a part of the coil instrument can be brokenIn2  (by default the point of release is the end of the straight length)
+    bool breaksInTwo(const Real& x_min_out, Real& x_break, int& numBeamsNotUnderControlled) {
+        SOFA_UNUSED(x_min_out);
+        SOFA_UNUSED(x_break);
+        SOFA_UNUSED(numBeamsNotUnderControlled);
+        msg_warning() << "Releasing catheter or brokenIn2 mode is not anymore supported. Feature has been removed after release v23.06";
+        return 0.0;
+    }
 };
 
 

--- a/src/BeamAdapter/component/WireBeamInterpolation.inl
+++ b/src/BeamAdapter/component/WireBeamInterpolation.inl
@@ -231,7 +231,7 @@ bool WireBeamInterpolation<DataTypes>::getApproximateCurvAbs(const Vec3& x_input
     return projected;
 }
 
-}
+
 
 template<class DataTypes>
 template<class T>
@@ -271,6 +271,7 @@ typename T::SPtr  WireBeamInterpolation<DataTypes>::create(T* tObj, core::object
     return obj;
 }
 
+}
 
 } // namespace _wirebeaminterpolation_
 

--- a/src/BeamAdapter/component/WireBeamInterpolation.inl
+++ b/src/BeamAdapter/component/WireBeamInterpolation.inl
@@ -62,7 +62,7 @@ void WireBeamInterpolation<DataTypes>::init()
     if( m_restShape.get() == nullptr )
     {
         msg_error() << "Missing WireRestShape. The component is thus de-activated" ;
-        this->d_componentState = sofa::core::objectmodel::ComponentState::Invalid ;
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         return;
     }
 
@@ -70,6 +70,8 @@ void WireBeamInterpolation<DataTypes>::init()
     type::vector< int> nbP_density;
 
     m_restShape.get()->getSamplingParameters(xP_noticeable, nbP_density);
+
+    this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 
@@ -152,50 +154,6 @@ void WireBeamInterpolation<DataTypes>::getSplineRestTransform(unsigned int edgeI
 }
 
 
-
-template<class DataTypes>
-void WireBeamInterpolation<DataTypes>::getBeamAtCurvAbs(const Real& x_input, unsigned int &edgeInList_output,
-                                                        Real& baryCoord_output, unsigned int start)
-{
-    if(this->m_brokenInTwo )
-    {
-        Real x_abs_broken = this->m_restShape.get()->getReleaseCurvAbs();
-
-        ////////// case 1.a : broken part !!
-        if (x_input > x_abs_broken)
-        {
-
-            /// x_i = curv_abs from the begining of the broken part
-            Real x_i = x_input-x_abs_broken;
-            Real x=0.0;
-
-            for (unsigned int e=0; e<this->m_numBeamsNotUnderControl; e++)
-            {
-                x += this->getLength(e);
-                if(x > x_i)
-                {
-                    edgeInList_output = e;
-                    Real x0 = x - this->getLength(e);
-                    baryCoord_output =(x_i-x0) / this->getLength(e);
-                    return;
-                }
-            }
-
-            edgeInList_output = this->m_numBeamsNotUnderControl-1;
-            baryCoord_output = 1.0;
-            return;
-
-        }
-        ////////// case 1.b : controlled part !!
-        else
-        {
-            start = this->m_numBeamsNotUnderControl;
-        }
-    }
-
-    Inherited::getBeamAtCurvAbs(x_input, edgeInList_output, baryCoord_output, start);
-}
-
 template<class DataTypes>
 void WireBeamInterpolation<DataTypes>::getCurvAbsAtBeam(const unsigned int &edgeInList_input, const Real& baryCoord_input, Real& x_output)
 {
@@ -273,80 +231,6 @@ bool WireBeamInterpolation<DataTypes>::getApproximateCurvAbs(const Vec3& x_input
     return projected;
 }
 
-
-template<class DataTypes>
-bool WireBeamInterpolation<DataTypes>::breaksInTwo(const Real &x_min_out,  Real &x_break, int &numBeamsNotUnderControlled )
-{
-    const Real eps = 0.0000000001;
-
-    if (this->m_brokenInTwo)
-    {
-        msg_error() << "Already broken" ;
-        return false;
-    }
-
-    if (!this->isControlled() || this->m_restShape == nullptr || x_min_out <= eps)
-    {
-        msg_error() << "Problem with function breaksInTwo ";
-        return false;
-    }
-
-    // if the release point is not "out" (x_min_out> x_break), then the break is not possible
-    x_break = m_restShape.get()->getReleaseCurvAbs();
-    if (x_min_out > x_break)
-        return false;
-
-    // put the info of the "released" part of the beam in the beginning of the beams;
-    this->m_numBeamsNotUnderControl=0;
-    unsigned int duplicatePoint=0;
-
-    // browse the curvilinear abscissa to find the point that needs to be duplicate
-    // put the info of the second part of the wire at the begining
-    unsigned int i=0;
-
-    auto edgeList = sofa::helper::getWriteOnlyAccessor(this->d_edgeList);
-    auto lengthList = sofa::helper::getWriteOnlyAccessor(this->d_lengthList);
-    auto DOF0TransformNode0 = sofa::helper::getWriteOnlyAccessor(this->d_DOF0TransformNode0);
-    auto DOF1TransformNode1 = sofa::helper::getWriteOnlyAccessor(this->d_DOF1TransformNode1);
-    auto curvAbsList = sofa::helper::getWriteOnlyAccessor(this->d_curvAbsList);
-
-    const unsigned int curvAbsListSize = curvAbsList.size();
-
-    for (unsigned int e = 1; e < curvAbsListSize; e++)
-    {
-        if (fabs(curvAbsList[e].x() - x_break) < eps)
-        {
-            duplicatePoint = e;
-            this->m_numBeamsNotUnderControl = curvAbsListSize - e;
-        }
-
-        if (curvAbsList[e].x() > (x_break - eps))
-        {
-            edgeList[i] = edgeList[e];
-            lengthList[i] = lengthList[e];
-            curvAbsList[i] = curvAbsList[e];
-
-            // When the instrument are rotated we apply a transformation between DOF and beam node
-            // (should always be the case and dofsAndBeamsAligned should be false)
-            if (!this->d_dofsAndBeamsAligned.getValue())
-            {
-                DOF0TransformNode0[i] = DOF0TransformNode0[e];
-                DOF1TransformNode1[i] = DOF1TransformNode1[e];
-            }
-
-            i++;
-        }
-    }
-
-    if (duplicatePoint == 0)
-        msg_error() << " Problem no point were found at the x_break position ! getReleaseCurvAbs() should provide a <<notable>> point" ;
-
-    m_restShape.get()->releaseWirePart();
-    numBeamsNotUnderControlled = this->m_numBeamsNotUnderControl;
-
-    this->m_brokenInTwo = true;
-
-    return true;
 }
 
 template<class DataTypes>

--- a/src/BeamAdapter/component/WireBeamInterpolation.inl
+++ b/src/BeamAdapter/component/WireBeamInterpolation.inl
@@ -271,8 +271,6 @@ typename T::SPtr  WireBeamInterpolation<DataTypes>::create(T* tObj, core::object
     return obj;
 }
 
-}
-
 } // namespace _wirebeaminterpolation_
 
 } // namespace sofa::component::fem

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -785,9 +785,6 @@ void InterventionalRadiologyController<DataTypes>::applyInterventionalRadiologyC
     unsigned int previousNumControlledNodes = m_numControlledNodes;
     unsigned int seg_remove = 0;
 
-    if (m_dropCall)
-        processDrop(previousNumControlledNodes, seg_remove);
-
     // ## STEP 1: Find the total length of the COMBINED INSTRUMENTS and the one for which xtip > 0 (so the one which are simulated)
     helper::AdvancedTimer::stepBegin("step1");
     Real totalLengthCombined=0.0;


### PR DESCRIPTION
Remove all code related to drop / brokenIn2 tool. This was use to simulate the drop of a part of the catheter during a procedure. 

This code is not really working anymore and should be re-implemented, if needed, using for example engine or dedicated component instead of changing directly the structure of the beam in the RestShape / interpolation components.