### PR TITLE
[InterventionalRadiologyController] Split and rename methods sortCurvAbs and interventionalRadiologyComputeSampling for more clarity

### DIFF
--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.h
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.h
@@ -130,11 +130,26 @@ public:
 
     /// Interface for interventionalRadiology instruments:
     virtual void applyInterventionalRadiologyController(void);
-
+    
     void processDrop(unsigned int &previousNumControlledNodes,  unsigned int &seg_remove);
-    void interventionalRadiologyComputeSampling(type::vector<Real> &newCurvAbs, type::vector< type::vector<int> > &id_instrument_table, const type::vector<Real> &xBegin, const Real& xEnd);
-    /// Sort the curv Abs in the ascending order and avoid doubloon
-    void sortCurvAbs(type::vector<Real> &CurvAbs, type::vector< type::vector<int> >& id_instrument_table);
+    
+private:
+    /// <summary>
+    /// Compute the sambling curv abscisses using each instrument sampling and key points parameters
+    /// Will call @sa sortCurvAbs to sort the curv abs and remove doubloon
+    /// </summary>
+    /// <param name="newCurvAbs"></param>
+    /// <param name="id_instrument_table"></param>
+    /// <param name="xBegin"></param>
+    /// <param name="xEnd"></param>
+    void computeInstrumentsCurvAbs(type::vector<Real>& newCurvAbs, const type::vector<Real>& tools_xBegin, const Real& totalLength);
+
+    /// Method to sort the curv Abs in the ascending order and avoid doubloon
+    void sortCurvAbs(type::vector<Real>& curvAbs);
+
+    void fillInstrumentCurvAbsMap(const type::vector<Real>& curvAbs, const type::vector<Real>& tools_xBegin, const type::vector<Real>& tools_xEnd, type::vector< type::vector<int> >& id_instrument_table);
+
+public:
     void totalLengthIsChanging(const type::vector<Real>& newNodeCurvAbs, type::vector<Real>& modifiedNodeCurvAbs, const type::vector< type::vector<int> >& newTable);
     void fixFirstNodesWithUntil(unsigned int first_simulated_Node);
     void activateBeamListForCollision( type::vector<Real> &curv_abs, type::vector< type::vector<int> > &id_instrument_table);

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.h
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.h
@@ -134,20 +134,17 @@ public:
     void processDrop(unsigned int &previousNumControlledNodes,  unsigned int &seg_remove);
     
 private:
-    /// <summary>
-    /// Compute the sambling curv abscisses using each instrument sampling and key points parameters
-    /// Will call @sa sortCurvAbs to sort the curv abs and remove doubloon
-    /// </summary>
-    /// <param name="newCurvAbs"></param>
-    /// <param name="id_instrument_table"></param>
-    /// <param name="xBegin"></param>
-    /// <param name="xEnd"></param>
+    /** Compute the sambling curv abscisses using each instrument sampling and key points parameters
+    * Will call @sa sortCurvAbs to sort the curv abs and remove doubloon
+    * Need each tool starting position to sample only activated nodes and tool total length (combined deployed tool lengths)
+    **/
     void computeInstrumentsCurvAbs(type::vector<Real>& newCurvAbs, const type::vector<Real>& tools_xBegin, const Real& totalLength);
 
-    /// Method to sort the curv Abs in the ascending order and avoid doubloon
+    /// Method to sort the curv Abs in the ascending order and remove doubloon that are closer than d_threshold
     void sortCurvAbs(type::vector<Real>& curvAbs);
 
-    void fillInstrumentCurvAbsMap(const type::vector<Real>& curvAbs, const type::vector<Real>& tools_xBegin, const type::vector<Real>& tools_xEnd, type::vector< type::vector<int> >& id_instrument_table);
+    /// Method to fill the id_instrument_table based on curvAbs and each tool begin and end. The table as the same size as the curvAbs buffer and store for each curvAbs[i] a vector with the ids of the instruments that are present at this position.
+    void fillInstrumentCurvAbsTable(const type::vector<Real>& curvAbs, const type::vector<Real>& tools_xBegin, const type::vector<Real>& tools_xEnd, type::vector< type::vector<int> >& id_instrument_table);
 
 public:
     void totalLengthIsChanging(const type::vector<Real>& newNodeCurvAbs, type::vector<Real>& modifiedNodeCurvAbs, const type::vector< type::vector<int> >& newTable);

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -788,8 +788,7 @@ void InterventionalRadiologyController<DataTypes>::applyInterventionalRadiologyC
     if (m_dropCall)
         processDrop(previousNumControlledNodes, seg_remove);
 
-    /// STEP 1
-    /// Find the total length of the COMBINED INSTRUMENTS and the one for which xtip > 0 (so the one which are simulated)
+    // ## STEP 1: Find the total length of the COMBINED INSTRUMENTS and the one for which xtip > 0 (so the one which are simulated)
     helper::AdvancedTimer::stepBegin("step1");
     Real totalLengthCombined=0.0;
     type::vector<Real> tools_xBegin;
@@ -827,23 +826,22 @@ void InterventionalRadiologyController<DataTypes>::applyInterventionalRadiologyC
     helper::AdvancedTimer::stepEnd("step1");
 
 
-    computeInstrumentsCurvAbs(newCurvAbs, tools_xBegin, totalLengthCombined);
-    /// STEP 2:
-    /// get the noticeable points that need to be simulated
-    // Fill=> newCurvAbs which provides a vector with curvilinear abscissa of each simulated node
-    //     => id_instrument_table which provides for each simulated node, the id of all instruments which belong this node
+    // ## STEP 2: Get the noticeable points that need to be simulated
+    //     => Fill newCurvAbs which provides a vector with curvilinear abscissa of each simulated node    
     //     => xbegin (theoritical curv abs of the beginning point of the instrument (could be negative) xbegin= xtip - intrumentLength)
-    helper::AdvancedTimer::stepBegin("step2");
+    helper::AdvancedTimer::stepBegin("step2");    
+    computeInstrumentsCurvAbs(newCurvAbs, tools_xBegin, totalLengthCombined);
+
+    //     => id_instrument_table which provides for each simulated node, the id of all instruments which belong this node
     type::vector<type::vector<int>> idInstrumentTable;
     fillInstrumentCurvAbsMap(newCurvAbs, tools_xBegin, tools_xEnd, idInstrumentTable);
     helper::AdvancedTimer::stepEnd("step2");
 
 
-    /// STEP 3
-    /// Re-interpolate the positions and the velocities
+    // ## STEP 3: Re-interpolate the positions and the velocities
     helper::AdvancedTimer::stepBegin("step3");
 
-    // Get write access to current nodes/dofs
+    //    => Get write access to current nodes/dofs
     Data<VecCoord>* datax = this->getMechanicalState()->write(core::VecCoordId::position());
     auto x = sofa::helper::getWriteOnlyAccessor(*datax);
     VecCoord xbuf = x.ref();
@@ -852,7 +850,7 @@ void InterventionalRadiologyController<DataTypes>::applyInterventionalRadiologyC
     const sofa::Size prev_nbrCurvAbs = m_nodeCurvAbs.size(); // previous number of simulated nodes;
     const Real prev_maxCurvAbs = m_nodeCurvAbs.back();
            
-    // Change curv if totalLength has changed: modifiedCurvAbs = newCurvAbs - current motion (Length between new and old tip curvAbs)
+    //    => Change curv if totalLength has changed: modifiedCurvAbs = newCurvAbs - current motion (Length between new and old tip curvAbs)
     type::vector<Real> modifiedCurvAbs;
     totalLengthIsChanging(newCurvAbs, modifiedCurvAbs, idInstrumentTable);
 
@@ -861,7 +859,7 @@ void InterventionalRadiologyController<DataTypes>::applyInterventionalRadiologyC
 
     for (sofa::Index xId = 0; xId < nbrCurvAbs; xId++)
     {
-        const sofa::Index globalNodeId = nbrUnactiveNode + xId;
+        const sofa::Index globalNodeId = nbrUnactiveNode + xId; // fill the end of the dof buffer
         const Real xCurvAbs = modifiedCurvAbs[xId];
         
         // 2 cases:  TODO : remove first case
@@ -894,7 +892,7 @@ void InterventionalRadiologyController<DataTypes>::applyInterventionalRadiologyC
 
             if (fabs(prev_xCurvAbs - xCurvAbs) < threshold)
             {
-                x[globalNodeId] = xbuf[prev_globalNodeId];
+                x[globalNodeId] = xbuf[prev_globalNodeId]; // xBuf all initialised at start with d_startingPos
             }
             else
             {
@@ -932,8 +930,7 @@ void InterventionalRadiologyController<DataTypes>::applyInterventionalRadiologyC
     helper::AdvancedTimer::stepEnd("step3");
 
 
-    /// STEP 4
-    /// Assign the beams
+    // ## STEP 4: Assign the beams
     helper::AdvancedTimer::stepBegin("step4");
     sofa::Size nbrBeam = newCurvAbs.size() - 1; // number of simulated beams
     unsigned int numEdges= m_numControlledNodes-1;
@@ -975,16 +972,15 @@ void InterventionalRadiologyController<DataTypes>::applyInterventionalRadiologyC
     }
     helper::AdvancedTimer::stepEnd("step4");
 
-    /// STEP 5
-    /// Fix the not simulated nodes
+
+    // ## STEP 5: Fix the not simulated nodes
     helper::AdvancedTimer::stepBegin("step5");
     unsigned int firstSimulatedNode = m_numControlledNodes - nbrBeam;
 
-    //1. Fix the nodes (beginning of the instruments) that are not "out"
+    //    => 1. Fix the nodes (beginning of the instruments) that are not "out"
     fixFirstNodesWithUntil(firstSimulatedNode);
 
-    //2. Fix the node that are "fixed"
-    // When there are rigid segments, # of dofs is different than # of edges and beams
+    //    => 2. Fix the node that are "fixed". When there are rigid segments, # of dofs is different than # of edges and beams
     const std::vector< Real > *rigidCurvAbs = &d_rigidCurvAbs.getValue();
 
     bool rigid=false;
@@ -1021,14 +1017,14 @@ void InterventionalRadiologyController<DataTypes>::applyInterventionalRadiologyC
         }
 
     }
+    helper::AdvancedTimer::stepEnd("step5");
 
-    /// STEP 6
-    /// Activate Beam List for collision of each instrument
+    // ## STEP 6: Activate Beam List for collision of each instrument
     activateBeamListForCollision(newCurvAbs,idInstrumentTable);
 
+    // ## STEP 7: Save new computed Data
     m_nodeCurvAbs = newCurvAbs;
     m_idInstrumentCurvAbsTable = idInstrumentTable;
-    helper::AdvancedTimer::stepEnd("step5");
 }
 
 template <class DataTypes>

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -834,7 +834,7 @@ void InterventionalRadiologyController<DataTypes>::applyInterventionalRadiologyC
 
     //     => id_instrument_table which provides for each simulated node, the id of all instruments which belong this node
     type::vector<type::vector<int>> idInstrumentTable;
-    fillInstrumentCurvAbsMap(newCurvAbs, tools_xBegin, tools_xEnd, idInstrumentTable);
+    fillInstrumentCurvAbsTable(newCurvAbs, tools_xBegin, tools_xEnd, idInstrumentTable);
     helper::AdvancedTimer::stepEnd("step2");
 
 
@@ -1076,7 +1076,7 @@ void InterventionalRadiologyController<DataTypes>::sortCurvAbs(type::vector<Real
 
 
 template <class DataTypes>
-void InterventionalRadiologyController<DataTypes>::fillInstrumentCurvAbsMap(const type::vector<Real>& curvAbs, 
+void InterventionalRadiologyController<DataTypes>::fillInstrumentCurvAbsTable(const type::vector<Real>& curvAbs, 
     const type::vector<Real>& tools_xBegin,
     const type::vector<Real>& tools_xEnd,
     type::vector< type::vector<int> >& idInstrumentTable)


### PR DESCRIPTION
Only cleaning/renaming to clarify the code. No behavior change.

- Rename method: `interventionalRadiologyComputeSampling `into `computeInstrumentsCurvAbs`
- spit method `sortCurvAbs ` into 2 methods:
  - a first method `sortCurvAbs `which only sort curvAbs 
  - a second method `fillInstrumentCurvAbsTable` which compute the id_instrument_table based on the curvAbs 
- Update some code comments in the main loop

Update methods doc and change the parameters methods to pass only the needed data