### PR TITLE
Fix wrong assets source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
         with:
           name: ${{ github.ref_name }}
           tag_name: release-${{ github.ref_name }}
-          fail_on_unmatched_files: true
+          fail_on_unmatched_files: false
           target_commitish: ${{ github.ref_name }}
           files: |
             artifacts/BeamAdapter_*_Linux.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
           name: ${{ github.ref_name }}
           tag_name: release-${{ github.ref_name }}
           fail_on_unmatched_files: true
+          target_commitish: ${{ github.ref_name }}
           files: |
             artifacts/BeamAdapter_*_Linux.zip
             artifacts/BeamAdapter_*_Windows.zip


### PR DESCRIPTION
Propagates #108 into `master`.
The `softprops/action-gh-release` Github action used in the CI to deploy assets was incorrectly configured to the `master` branch (default behavior), instead of the current release set by the `sofa_branch` field in the `build-and-test` matrix.
This lead to the following undesired behavior:
- source code archives (zip and tar) were generated from master branch instead of release branch. Other assets (releases for Windows, Linux and MacOS) were generated from correct branch.
- release tag pushed by this action (tag in the form `release-<version>`) was incorrectly set to `master` branch, which is invalid when current release is not `master` (such as `v<version>`)

This PR also allow the creation of the release to continue on failure, which typically occurs if one asset is missing such the macOS archive as the macCI is down. Similarly to what has been proposed to SofaPython3, SoftRobots, STLIB, Cosserat and ModelOrderReduction plugins.