### PR TITLE
[BeamAdapterActionController] Update Actions reading/writting and IRCtrl control

### DIFF
--- a/src/BeamAdapter/component/controller/BeamAdapterActionController.inl
+++ b/src/BeamAdapter/component/controller/BeamAdapterActionController.inl
@@ -31,7 +31,7 @@ using namespace sofa::beamadapter;
 
 template <class DataTypes>
 BeamAdapterActionController<DataTypes>::BeamAdapterActionController()
-    : d_writeMode(initData(&d_writeMode, false, "writeMode", "If true, will accumulate actions from keyboard and dump the actions and times when key 'E' is pressed."))
+    : d_writeMode(initData(&d_writeMode, true, "writeMode", "If true, will accumulate actions from keyboard and dump the actions and times when key 'E' is pressed."))
     , d_actions(initData(&d_actions, "actions", "List of actions to script the BeamAdapter"))
     , d_actionString(initData(&d_actionString, "actionString", "List of actions as string to script the BeamAdapter"))
     , d_timeSteps(initData(&d_timeSteps, "timeSteps", "List of key times corresponding to the actions"))
@@ -52,6 +52,11 @@ void BeamAdapterActionController<DataTypes>::init()
 
     // the controller must listen to the event (in particular BeginAnimationStep event)
     this->f_listening.setValue(true);
+
+    if (d_writeMode.getValue() && (d_actions.isSet() || d_actionString.isSet()))
+    {
+        msg_warning() << "WriteMode is set to on but a list of actions has been set as input. The list will be overwritten.";
+    }
 
     this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }

--- a/src/BeamAdapter/component/controller/BeamAdapterActionController.inl
+++ b/src/BeamAdapter/component/controller/BeamAdapterActionController.inl
@@ -131,24 +131,17 @@ void BeamAdapterActionController<DataTypes>::onBeginAnimationStep(const double /
     else
     {
         const type::vector<Real>& times = d_timeSteps.getValue();
-        if (!times.empty())
-        {            
-            if (m_readStep < times.size())
-            {
-                Real time = times[m_readStep];
-                if (currentTime >= time) // check if another key time has been reached and change action
-                {
-                    m_currAction = BeamAdapterAction(d_actions.getValue()[m_readStep]);
-                    m_readStep++;
-                }
-            }
+        if (!times.empty() && m_readStep < times.size())
+        {
+            const Real& time = times[m_readStep];
 
-            interventionCtrl* ctrl = l_interventionController.get();
-            ctrl->applyAction(m_currAction);
+            if (currentTime >= time) // check if another key time has been reached and change action
+            {                
+                m_currAction = BeamAdapterAction(d_actions.getValue()[m_readStep]);
+                m_readStep++;
 
-            if (m_currAction >= BeamAdapterAction::SWITCH_NEXT_TOOL) // action regarding tool needs only to be triggered once
-            {
-                m_currAction = BeamAdapterAction::NO_ACTION;
+                interventionCtrl* ctrl = l_interventionController.get();
+                ctrl->applyAction(m_currAction);
             }
         }
     }

--- a/src/BeamAdapter/component/controller/BeamAdapterActionController.inl
+++ b/src/BeamAdapter/component/controller/BeamAdapterActionController.inl
@@ -114,13 +114,13 @@ template <class DataTypes>
 void BeamAdapterActionController<DataTypes>::onBeginAnimationStep(const double /*dt*/)
 {
     const auto currentTime = this->getContext()->getTime();
+    interventionCtrl* ctrl = l_interventionController.get();
 
     if (d_writeMode.getValue())
     {
         if (m_currAction == BeamAdapterAction::NO_ACTION)
-            return;
+            return ctrl->applyInterventionalRadiologyController();
 
-        interventionCtrl* ctrl = l_interventionController.get();
         ctrl->applyAction(m_currAction);
 
         auto times = sofa::helper::WriteAccessor(d_timeSteps);
@@ -149,11 +149,12 @@ void BeamAdapterActionController<DataTypes>::onBeginAnimationStep(const double /
                 m_currAction = BeamAdapterAction(d_actions.getValue()[m_readStep]);
                 m_readStep++;
 
-                interventionCtrl* ctrl = l_interventionController.get();
                 ctrl->applyAction(m_currAction);
             }
         }
     }
+
+    ctrl->applyInterventionalRadiologyController();
 }
 
 

--- a/src/BeamAdapter/component/controller/BeamAdapterActionController.inl
+++ b/src/BeamAdapter/component/controller/BeamAdapterActionController.inl
@@ -83,32 +83,16 @@ void BeamAdapterActionController<DataTypes>::onKeyPressedEvent(core::objectmodel
         m_currAction = BeamAdapterAction::USE_TOOL_0;
         break;
     case 20: // droite = 20
-        if (m_currAction == BeamAdapterAction::SPIN_RIGHT)
-            m_currAction = BeamAdapterAction::NO_ACTION;
-        else
-            m_currAction = BeamAdapterAction::SPIN_RIGHT;
-
+        m_currAction = BeamAdapterAction::SPIN_RIGHT;
         break;
     case 18: // gauche = 18
-        if (m_currAction == BeamAdapterAction::SPIN_LEFT)
-            m_currAction = BeamAdapterAction::NO_ACTION;
-        else
-            m_currAction = BeamAdapterAction::SPIN_LEFT;
-
+        m_currAction = BeamAdapterAction::SPIN_LEFT;
         break;
     case 19: // fleche haut = 19
-        if (m_currAction == BeamAdapterAction::MOVE_FORWARD)
-            m_currAction = BeamAdapterAction::NO_ACTION;
-        else
-            m_currAction = BeamAdapterAction::MOVE_FORWARD;
-        
+        m_currAction = BeamAdapterAction::MOVE_FORWARD;
         break;
     case 21: // bas = 21
-        if (m_currAction == BeamAdapterAction::MOVE_BACKWARD)
-            m_currAction = BeamAdapterAction::NO_ACTION;
-        else
-            m_currAction = BeamAdapterAction::MOVE_BACKWARD;
-
+        m_currAction = BeamAdapterAction::MOVE_BACKWARD;
         break;
     default:
         m_currAction = BeamAdapterAction::NO_ACTION;
@@ -121,31 +105,28 @@ template <class DataTypes>
 void BeamAdapterActionController<DataTypes>::onBeginAnimationStep(const double /*dt*/)
 {
     const auto currentTime = this->getContext()->getTime();
+
     if (d_writeMode.getValue())
     {
+        if (m_currAction == BeamAdapterAction::NO_ACTION)
+            return;
+
         interventionCtrl* ctrl = l_interventionController.get();
         ctrl->applyAction(m_currAction);
 
-        if (m_lastAction != m_currAction)
+        auto times = sofa::helper::WriteAccessor(d_timeSteps);
+        auto actions = sofa::helper::WriteAccessor(d_actions);
+        times.push_back(currentTime);
+        actions.push_back(int(m_currAction));
+
+        if (m_exportActions)
         {
-            auto times = sofa::helper::WriteAccessor(d_timeSteps);
-            auto actions = sofa::helper::WriteAccessor(d_actions);
-            times.push_back(currentTime);
-            actions.push_back(int(m_currAction));
-
-            if (m_exportActions)
-            {
-                std::cout << "timeSteps='" << times.wref() << "'" << std::endl;
-                std::cout << "actions='" << actions.wref() << "'" << std::endl;
-            }
-
-            m_lastAction = m_currAction;
+            std::cout << "timeSteps='" << times.wref() << "'" << std::endl;
+            std::cout << "actions='" << actions.wref() << "'" << std::endl;
         }
 
-        if (m_currAction >= BeamAdapterAction::SWITCH_NEXT_TOOL) // action regarding tool needs only to be triggered once
-        {
-            m_currAction = BeamAdapterAction::NO_ACTION;
-        }
+        m_lastAction = m_currAction;
+        m_currAction = BeamAdapterAction::NO_ACTION;
     }
     else
     {

--- a/src/BeamAdapter/component/controller/BeamAdapterActionController.inl
+++ b/src/BeamAdapter/component/controller/BeamAdapterActionController.inl
@@ -48,6 +48,7 @@ void BeamAdapterActionController<DataTypes>::init()
     {
         msg_error() << "No l_interventionController given. Component will be set to Invalid.";
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
     }
 
     // the controller must listen to the event (in particular BeginAnimationStep event)
@@ -57,6 +58,9 @@ void BeamAdapterActionController<DataTypes>::init()
     {
         msg_warning() << "WriteMode is set to on but a list of actions has been set as input. The list will be overwritten.";
     }
+
+    interventionCtrl* ctrl = l_interventionController.get();
+    ctrl->useBeamAction(true);
 
     this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.h
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.h
@@ -110,6 +110,8 @@ public:
     int getTotalNbEdges()const;
 
     void applyAction(sofa::beamadapter::BeamAdapterAction action);
+    /// Method to warn this controller that a BeamActionController is controlling the scene. Will bypass the event handling in this component.
+    void useBeamAction(bool value) { m_useBeamActions = value; }
 
     /// Getter to the tools curviline abscisses sorted @sa m_nodeCurvAbs at the current timestep.
     [[nodiscard]] const type::vector<Real>& getCurrentCurvAbscisses() const { return m_nodeCurvAbs; }
@@ -153,7 +155,7 @@ public:
     Data<unsigned int>   d_indexFirstNode; // First Node simulated
     
     
-
+    bool m_useBeamActions = false;
     bool m_FF, m_RW, m_sensored;
     FixedConstraint<DataTypes> *    m_fixedConstraint;
     type::vector<int>                     m_droppedInstruments;

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -248,6 +248,9 @@ void InterventionalRadiologyController<DataTypes>::onMouseEvent(MouseEvent * mev
 template <class DataTypes>
 void InterventionalRadiologyController<DataTypes>::onKeyPressedEvent(KeypressedEvent *kev)
 {
+    if (m_useBeamActions)
+        return;
+
     /// Control keys for interventonal Radiology simulations:
     switch(kev->getKey())
     {
@@ -308,6 +311,9 @@ template <class DataTypes>
 void InterventionalRadiologyController<DataTypes>::onBeginAnimationStep(const double dt)
 {
     SOFA_UNUSED(dt);
+
+    if (m_useBeamActions)
+        return applyInterventionalRadiologyController();
 
     BaseContext* context = getContext();
     auto xInstrTip = sofa::helper::getWriteOnlyAccessor(d_xTip);

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -313,7 +313,7 @@ void InterventionalRadiologyController<DataTypes>::onBeginAnimationStep(const do
     SOFA_UNUSED(dt);
 
     if (m_useBeamActions)
-        return applyInterventionalRadiologyController();
+        return;
 
     BaseContext* context = getContext();
     auto xInstrTip = sofa::helper::getWriteOnlyAccessor(d_xTip);


### PR DESCRIPTION
Update `BeamAdapterActionController ` behavior:
**Before:** pressing for example key up was moving the tool forward until another action was ordered.
**Now:**: pressing a key perform only one action for the current timestep. 
This create bigger Actions and keytimes vectors but allow a smoother description and can be replay without any problem of timestep precision. 

Add mechanism in `InterventionalRadiologyController `  using bool `m_useBeamActions ` to know that is is now controlled by a 
`BeamAdapterActionController `. At this point, events are skipped in `InterventionalRadiologyController ` and everything is handled in the `BeamAdapterActionController `.