### PR TITLE
Add relative path to references files into regression-tests files

### DIFF
--- a/examples/RegressionStateScenes.regression-tests
+++ b/examples/RegressionStateScenes.regression-tests
@@ -2,6 +2,9 @@
 # REGRESSION_TEST DOES NOT SUPPORT DASHES ("-") IN SCENE NAMES.
 # USE UNDERSCORES ("_") INSTEAD.
 
+### References relative path ###
+../regression/references
+
 ### Demo scenes ###
 SingleBeam.scn 1000 1e-4 1 1
 SingleBeamDeployment.scn 1000 1e-4 1 1


### PR DESCRIPTION
This PR is based on [PR #56](https://github.com/sofa-framework/Regression/pull/56) of Regression. 

This PR fixes the problem of running regression tests in plugins when their references are inside of the plugin and not Regression (e.g. BeamAdapter)

The idea is to have a stand alone `*.regression.tests` file that also includes the relative path of the reference folder. This is meant to be placed at the top of the reference file in a relative manne. This allows two things : 
1. Having a stand alone file ease the process of finding the reference folder for any new comer
2. Having a stand alone file ease the process of automatizing the retrieval of new regression test along with their reference folder without the need of modifying anything in the CI script.    