### PR TITLE
[scenes] Fix python scenes using the new Section Material components

### DIFF
--- a/examples/python3/Cochlear-Implant-Insertion/Scene_Cochlea.py
+++ b/examples/python3/Cochlear-Implant-Insertion/Scene_Cochlea.py
@@ -8,17 +8,18 @@ path = os.path.dirname(os.path.abspath(__file__))+'/mesh/'
 def createScene(rootNode):
         rootNode.addObject('RequiredPlugin',name='BeamAdapter', pluginName='BeamAdapter ')
         rootNode.addObject('RequiredPlugin',name='SofaPython3', pluginName='SofaPython3')
-        rootNode.addObject('RequiredPlugin',name='SOFA Modules', pluginName='Sofa.Component.AnimationLoop Sofa.Component.Collision.Detection.Algorithm Sofa.Component.Collision.Detection.Intersection Sofa.Component.Collision.Geometry Sofa.Component.Collision.Response.Contact Sofa.Component.Constraint.Lagrangian.Correction Sofa.Component.Constraint.Lagrangian.Solver Sofa.Component.Constraint.Projective Sofa.Component.IO.Mesh Sofa.Component.LinearSolver.Direct Sofa.Component.ODESolver.Backward Sofa.Component.SolidMechanics.Spring Sofa.Component.Topology.Container.Constant Sofa.Component.Topology.Container.Dynamic Sofa.Component.Topology.Container.Grid  Sofa.Component.Topology.Mapping Sofa.Component.Visual Sofa.GL.Component.Rendering3D')
+        rootNode.addObject('RequiredPlugin',name='SOFA Modules', pluginName='Sofa.Component.AnimationLoop Sofa.Component.Collision.Detection.Algorithm Sofa.Component.Collision.Detection.Intersection Sofa.Component.Collision.Geometry Sofa.Component.Collision.Response.Contact Sofa.Component.Constraint.Lagrangian.Correction Sofa.Component.Constraint.Lagrangian.Solver Sofa.Component.Constraint.Projective Sofa.Component.IO.Mesh Sofa.Component.LinearSolver.Direct Sofa.Component.ODESolver.Backward Sofa.Component.SolidMechanics.Spring Sofa.Component.Topology.Container.Constant Sofa.Component.Topology.Container.Dynamic Sofa.Component.Topology.Container.Grid Sofa.Component.Mapping.Linear Sofa.Component.Topology.Mapping Sofa.Component.StateContainer Sofa.Component.Visual Sofa.GL.Component.Rendering3D')
         rootNode.findData('dt').value=0.01
         rootNode.findData('gravity').value=[0,0,0]
         rootNode.addObject('VisualStyle', displayFlags='showVisualModels hideBehaviorModels showCollisionModels hideMappings hideForceFields showInteractionForceFields hideWireframe')
+
         rootNode.addObject('DefaultVisualManagerLoop')
         rootNode.addObject('FreeMotionAnimationLoop')
         rootNode.addObject('GenericConstraintSolver', tolerance="1e-3", maxIterations="5000", unbuilt="false")
-        rootNode.addObject('DefaultPipeline', depth="6", verbose="0", draw="1")
+        rootNode.addObject('CollisionPipeline', depth="6", verbose="0", draw="1")
         rootNode.addObject('BruteForceBroadPhase', name='N2')
         rootNode.addObject('BVHNarrowPhase')
-        rootNode.addObject('DefaultContactManager', response="FrictionContactConstraint", responseParams="mu=0.65")
+        rootNode.addObject('CollisionResponse', response="FrictionContactConstraint", responseParams="mu=0.65")
         rootNode.addObject('LocalMinDistance', name="Proximity", alarmDistance="0.6", contactDistance="0.44", angleCone="0.01")
 
 
@@ -32,8 +33,14 @@ def createScene(rootNode):
         visuCochleaNode = cochleaNode.addChild('visuCochleaNode')
         visuCochleaNode.addObject('OglModel', name="VisualModel", color="3.0 0.5 0.0 0.9")
 
+
         topoLines_cath = rootNode.addChild('topoLines_cath')
-        topoLines_cath.addObject('WireRestShape', template="Rigid3d", printLog=False, name="catheterRestShape", length="20", straightLength="20", spireDiameter="0", spireHeight="0.0", densityOfBeams="40", numEdges="20", numEdgesCollis="20", youngModulus="2.5e5", youngModulusExtremity="2.5e5", radius="@../Proximity.contactDistance")
+        topoLines_cath.addObject('RodStraightSection', name='StraightSection', 
+                                 length=20.0, radius="@../Proximity.contactDistance", 
+                                 nbEdgesCollis=20, nbEdgesVisu=20, 
+                                 youngModulus=2.5e5, massDensity=0.000005, poissonRatio=0.3)
+
+        topoLines_cath.addObject('WireRestShape', name='catheterRestShape', template="Rigid3d", wireMaterials="@StraightSection")
         topoLines_cath.addObject('EdgeSetTopologyContainer', name="meshLinesCath")
         topoLines_cath.addObject('EdgeSetTopologyModifier', name="Modifier")
         topoLines_cath.addObject('EdgeSetGeometryAlgorithms', name="GeomAlgo", template="Rigid3d")
@@ -52,7 +59,7 @@ def createScene(rootNode):
         InstrumentCombined.addObject('WireBeamInterpolation', name="InterpolCatheter", WireRestShape="@../topoLines_cath/catheterRestShape", radius="3.0", printLog=False)
         InstrumentCombined.addObject('AdaptiveBeamForceFieldAndMass', name="CatheterForceField", massDensity="0.000005", interpolation="@InterpolCatheter", printLog=False)
         InstrumentCombined.addObject('LinearSolverConstraintCorrection', printLog=False, wire_optimization="true")
-        InstrumentCombined.addObject("FixedConstraint", indices="0")
+        InstrumentCombined.addObject("FixedProjectiveConstraint", indices="0")
         InstrumentCombined.addObject('RestShapeSpringsForceField', name="MeasurementFF", points="@m_ircontroller.indexFirstNode",  stiffness="1e10", recompute_indices="1", angularStiffness="1e10", external_rest_shape="@../RefStartingPos/ReferencePos", external_points="0", drawSpring="1", springColor="1 0 0 1")
 
         CollisInstrumentCombined = InstrumentCombined.addChild('CollisInstrumentCombined')

--- a/examples/python3/SingleBeam.py
+++ b/examples/python3/SingleBeam.py
@@ -4,19 +4,18 @@ import Sofa
 def createScene(rootNode):
 
     # rootNode
-    rootNode.addObject('RequiredPlugin', pluginName='BeamAdapter SofaBoundaryCondition SofaGeneralLinearSolver SofaConstraint SofaImplicitOdeSolver')
+    rootNode.addObject('RequiredPlugin', pluginName='BeamAdapter Sofa.Component.Constraint.Projective Sofa.Component.LinearSolver.Direct Sofa.Component.ODESolver.Backward Sofa.Component.StateContainer Sofa.Component.Topology.Container.Constant Sofa.Component.Topology.Container.Grid Sofa.Component.Visual')
     rootNode.addObject('VisualStyle', displayFlags='showBehaviorModels showCollisionModels hideBoundingCollisionModels showForceFields')
     rootNode.addObject('DefaultAnimationLoop')
     rootNode.addObject('DefaultVisualManagerLoop')
 
     # rootNode/BeamModel
-    BeamModel = rootNode.addChild('BeamModel')
-    BeamModel = BeamModel
+    BeamModel = rootNode.addChild('BeamModel', bbox="-3 -6 -3 3 3 3")
     BeamModel.addObject('EulerImplicitSolver', rayleighStiffness='0', rayleighMass='0', printLog='false')
     BeamModel.addObject('BTDLinearSolver', verbose='0')
-    BeamModel.addObject('MechanicalObject', template='Rigid3d', name='DOFs', position='0 0 0 0 0 0 1  2 0 0 0 0 0 1  4 0 0 0 0 0 1  6 0 0 0 0 0 1')
-    BeamModel.addObject('MeshTopology', name='lines', lines='0 1 1 2 2 3')
-    BeamModel.addObject('FixedConstraint', name='FixedConstraint', indices='0')
+    BeamModel.addObject('RegularGridTopology', name='MeshLines', n=[200, 1, 1], min=[0, 0, 0], max=[100, 0, 0])
+    BeamModel.addObject('MechanicalObject', template='Rigid3d', name='DOFs', position='@MeshLines.positions')
+    BeamModel.addObject('FixedProjectiveConstraint', name='FixedConstraint', indices='0')
     BeamModel.addObject('BeamInterpolation', name='BeamInterpolation', radius='0.1')
     BeamModel.addObject('AdaptiveBeamForceFieldAndMass', name='BeamForceField', computeMass='1', massDensity='10')
 

--- a/examples/python3/SingleBeamDeployment.py
+++ b/examples/python3/SingleBeamDeployment.py
@@ -3,29 +3,37 @@ import Sofa
 
 def createScene(rootNode):
 
-    rootNode.addObject('RequiredPlugin', pluginName='BeamAdapter SofaBoundaryCondition SofaConstraint SofaDeformable SofaGeneralLinearSolver SofaImplicitOdeSolver')
+    rootNode.addObject('RequiredPlugin', pluginName='BeamAdapter Sofa.Component.Constraint.Projective Sofa.Component.LinearSolver.Direct Sofa.Component.ODESolver.Backward Sofa.Component.StateContainer Sofa.Component.Topology.Container.Constant Sofa.Component.Topology.Container.Grid Sofa.Component.Visual Sofa.Component.SolidMechanics.Spring Sofa.Component.Topology.Container.Dynamic')
     rootNode.addObject('VisualStyle', displayFlags='showVisualModels showBehaviorModels showCollisionModels hideMappings showForceFields')
 
     rootNode.addObject('DefaultAnimationLoop')
     rootNode.addObject('DefaultVisualManagerLoop')
 
     topoLines = rootNode.addChild('EdgeTopology')
-    topoLines.addObject('WireRestShape', name='BeamRestShape', 
-                                 straightLength=980.0, length=1000.0, 
-                                 numEdges=200, youngModulus=20000, 
-                                 spireDiameter=25, numEdgesCollis=[50,10], 
-                                 printLog=True, template='Rigid3d', spireHeight=0.0, 
-                                 densityOfBeams=[30,5], youngModulusExtremity=20000)
+    topoLines.addObject('RodStraightSection', name='StraightSection', 
+                                 length=980.0, radius=1, 
+                                 nbEdgesCollis=30, nbEdgesVisu=196, 
+                                 youngModulus=20000)
+
+    topoLines.addObject('RodSpireSection', name='SpireSection', 
+                                 length=20.0, radius=1, 
+                                 nbEdgesCollis=5, nbEdgesVisu=4,
+                                 spireDiameter=25, spireHeight=0,
+                                 youngModulus=20000)
+    topoLines.addObject('WireRestShape', name='BeamRestShape', template="Rigid3d",
+                                 wireMaterials="@StraightSection @SpireSection")
+                                 
     topoLines.addObject('EdgeSetTopologyContainer', name='meshLinesBeam')
     topoLines.addObject('EdgeSetTopologyModifier', name='Modifier')
     topoLines.addObject('EdgeSetGeometryAlgorithms', name='GeomAlgo', template='Rigid3d')
     topoLines.addObject('MechanicalObject', name='dofTopo2', template='Rigid3d')
 
 
-    BeamMechanics = rootNode.addChild('BeamModel')
+
+    BeamMechanics = rootNode.addChild('BeamModel', bbox="0 0 0 10 10 10")
     BeamMechanics.addObject('EulerImplicitSolver', rayleighStiffness=0.2, printLog=False, rayleighMass=0.1)
     BeamMechanics.addObject('BTDLinearSolver', verification=False, subpartSolve=False, verbose=False)
-    BeamMechanics.addObject('RegularGridTopology', name='MeshLines', drawEdges=True 
+    BeamMechanics.addObject('RegularGridTopology', name='MeshLines', drawEdges=True, 
                                     nx=60, ny=1, nz=1,
                                     xmax=0.0, xmin=0.0, ymin=0, ymax=0, zmax=0, zmin=0,
                                     p0=[0,0,0])
@@ -37,7 +45,7 @@ def createScene(rootNode):
                                     startingPos=[0, 0, 0, 0, 0, 0, 1], xtip=[0, 0, 0], printLog=True, 
                                     rotationInstrument=[0, 0, 0], step=0.5, speed=0.5, 
                                     listening=True, controlledInstrument=0)
-    BeamMechanics.addObject('FixedConstraint', indices=0, name='FixedConstraint')
+    BeamMechanics.addObject('FixedProjectiveConstraint', indices=0, name='FixedConstraint')
     BeamMechanics.addObject('RestShapeSpringsForceField', name="RestSPForceField", points='@DeployController.indexFirstNode', angularStiffness=1e8, stiffness=1e8)
     
 

--- a/examples/python3/SingleBeamDeploymentCollision.py
+++ b/examples/python3/SingleBeamDeploymentCollision.py
@@ -3,30 +3,39 @@ import Sofa
 
 def createScene(rootNode):
 
-    rootNode.addObject('RequiredPlugin', pluginName='BeamAdapter SofaMeshCollision SofaBoundaryCondition SofaConstraint SofaMiscCollision SofaDeformable SofaGeneralLinearSolver SofaImplicitOdeSolver')
+    rootNode.addObject('RequiredPlugin', name="plug1", pluginName='BeamAdapter Sofa.Component.Constraint.Projective Sofa.Component.LinearSolver.Direct Sofa.Component.ODESolver.Backward Sofa.Component.StateContainer Sofa.Component.Topology.Container.Constant Sofa.Component.Topology.Container.Grid Sofa.Component.Visual Sofa.Component.SolidMechanics.Spring Sofa.Component.Topology.Container.Dynamic')
+    rootNode.addObject('RequiredPlugin', name="plug2", pluginName='Sofa.Component.AnimationLoop Sofa.Component.Collision.Detection.Algorithm Sofa.Component.Collision.Detection.Intersection Sofa.Component.Collision.Geometry Sofa.Component.Collision.Response.Contact Sofa.Component.Constraint.Lagrangian.Correction Sofa.Component.Constraint.Lagrangian.Solver Sofa.Component.IO.Mesh')
     rootNode.addObject('VisualStyle', displayFlags='hideVisualModels hideBehaviorModels showCollisionModels hideMappings showInteractionForceFields')
 
     rootNode.addObject('FreeMotionAnimationLoop')
     rootNode.addObject('DefaultVisualManagerLoop')
 
     rootNode.addObject('LCPConstraintSolver', mu='0.1', tolerance='1e-10', maxIt='1000', build_lcp='false')
-    rootNode.addObject('DefaultPipeline', draw='0', depth='6', verbose='1')
+    rootNode.addObject('CollisionPipeline', draw='0', depth='6', verbose='1')
     rootNode.addObject('BruteForceBroadPhase', name='N2')
     rootNode.addObject('BVHNarrowPhase')
-    rootNode.addObject('LocalMinDistance', contactDistance='1', alarmDistance='5', name='localmindistance', angleCone='0.02')
-    rootNode.addObject('DefaultContactManager', name='Response', response='FrictionContactConstraint')
+    rootNode.addObject('LocalMinDistance', contactDistance='0.1', alarmDistance='2', name='localmindistance', angleCone='0.2')
+    rootNode.addObject('CollisionResponse', name='Response', response='FrictionContactConstraint')
 
     topoLines = rootNode.addChild('EdgeTopology')
-    topoLines.addObject('WireRestShape', name='BeamRestShape', 
-                                 straightLength=980.0, length=1000.0, 
-                                 numEdges=200, youngModulus=20000, 
-                                 spireDiameter=25, numEdgesCollis=[50,10], 
-                                 printLog=True, template='Rigid3d', spireHeight=0.0, 
-                                 densityOfBeams=[30,5], youngModulusExtremity=20000)
+    topoLines.addObject('RodStraightSection', name='StraightSection', 
+                                 length=980.0, radius=1, 
+                                 nbEdgesCollis=50, nbEdgesVisu=200, 
+                                 youngModulus=20000, massDensity=0.1, poissonRatio=0.3)
+
+    topoLines.addObject('RodSpireSection', name='SpireSection', 
+                                 length=20.0, radius=1, 
+                                 nbEdgesCollis=10, nbEdgesVisu=200,
+                                 spireDiameter=25, spireHeight=0,
+                                 youngModulus=20000, massDensity=0.1, poissonRatio=0.3)
+    topoLines.addObject('WireRestShape', name='BeamRestShape', template="Rigid3d",
+                                 wireMaterials="@StraightSection @SpireSection")
+                                 
     topoLines.addObject('EdgeSetTopologyContainer', name='meshLines')
     topoLines.addObject('EdgeSetTopologyModifier', name='Modifier')
     topoLines.addObject('EdgeSetGeometryAlgorithms', name='GeomAlgo', template='Rigid3d')
     topoLines.addObject('MechanicalObject', name='dofTopo2', template='Rigid3d')
+
 
 
     BeamMechanics = rootNode.addChild('BeamModel')
@@ -45,7 +54,7 @@ def createScene(rootNode):
                                     rotationInstrument=[0, 0, 0], step=5., speed=5., 
                                     listening=True, controlledInstrument=0)
     BeamMechanics.addObject('LinearSolverConstraintCorrection', wire_optimization='true', printLog=False)
-    BeamMechanics.addObject('FixedConstraint', indices=0, name='FixedConstraint')
+    BeamMechanics.addObject('FixedProjectiveConstraint', indices=0, name='FixedConstraint')
     BeamMechanics.addObject('RestShapeSpringsForceField', points='@DeployController.indexFirstNode', angularStiffness=1e8, stiffness=1e8)
     
 


### PR DESCRIPTION
Fix the basic examples scenes using same parameters as the xml versions. (also clean warnings)

Also fix the [Scene_Cochlea.py](https://github.com/sofa-framework/BeamAdapter/compare/master...epernod:inf_python_scene?expand=1#diff-62304f9e52c9d1607150a46a855012082b455aca495d7bb211c277a19b521e75)

Not sure if the behavior is correct, this is a screenshot of what I get:

![Scene_Cochlea_00000001](https://github.com/sofa-framework/BeamAdapter/assets/21199245/1094bd72-7708-4ed1-ba52-99c4a4d9d39b)

fix #122 