### PR TITLE
Fix doc links using absolute path

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1602,4 +1602,7 @@ DOT_CLEANUP            = YES
 HTML_EXTRA_STYLESHEET = .github/doxygen-awesome-css/doxygen-awesome.css
 
 INPUT += doc/README.md
+INPUT += doc/modeling/theory.md
+INPUT += doc/modeling/implementation.md
+
 USE_MDFILE_AS_MAINPAGE = doc/README.md

--- a/doc/README.md
+++ b/doc/README.md
@@ -14,8 +14,8 @@ It also presents some examples of use and lists the current limitations.
 
 
 ## 2. Documentation cover:
-- [Modeling theory](modeling/theory.md)
-- [Modeling scene implementation](modeling/implementation.md)
+- [Modeling theory](https://github.com/sofa-framework/BeamAdapter/blob/master/doc/modeling/theory.md)
+- [Modeling scene implementation](https://github.com/sofa-framework/BeamAdapter/blob/master/doc/modeling/implementation.md)
 
 
 ## 3. Technical roadmap


### PR DESCRIPTION
Try to fix the links in the [doxygen doc](https://sofa-framework.github.io/BeamAdapter/index.html) in the documentation section