### PR TITLE
Initialize SofaCUDA

### DIFF
--- a/extensions/CUDA/src/BeamAdapter/CUDA/init.cpp
+++ b/extensions/CUDA/src/BeamAdapter/CUDA/init.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 #include <BeamAdapter/CUDA/init.h>
 #include <BeamAdapter/initBeamAdapter.h>
+#include <SofaCUDA/init.h>
 #include <sofa/core/ObjectFactory.h>
 namespace beamadapter::cuda
 {
@@ -53,6 +54,7 @@ void init()
     if (first)
     {
         sofa::component::initBeamAdapter();
+        sofa::gpu::cuda::init();
         first = false;
     }
 }


### PR DESCRIPTION
Based on https://github.com/sofa-framework/BeamAdapter/pull/132 and requires https://github.com/sofa-framework/sofa/pull/4453. Only the last commit is important.