### PR TITLE
[src] Use BaseBeamInterpolation in BeamMapping

### DIFF
--- a/src/BeamAdapter/component/BaseBeamInterpolation.h
+++ b/src/BeamAdapter/component/BaseBeamInterpolation.h
@@ -135,7 +135,7 @@ public:
     virtual void getInterpolationParam(unsigned int edgeInList, Real& _L, Real& _A, Real& _Iy, Real& _Iz,
         Real& _Asy, Real& _Asz, Real& J) = 0;
     virtual const BeamSection& getBeamSection(int edgeIndex) = 0;
-
+    virtual void getBeamAtCurvAbs(const Real& x_input, unsigned int& edgeInList_output, Real& baryCoord_output, unsigned int start = 0);
 
     int computeTransform(const EdgeID edgeInList, Transform& global_H_local0, Transform& global_H_local1, const VecCoord& x);
     int computeTransform(const EdgeID edgeInList, const PointID node0Idx, const PointID node1Idx, Transform& global_H_local0, Transform& global_H_local1, const VecCoord& x);

--- a/src/BeamAdapter/component/BaseBeamInterpolation.inl
+++ b/src/BeamAdapter/component/BaseBeamInterpolation.inl
@@ -258,6 +258,52 @@ int BaseBeamInterpolation<DataTypes>::computeTransform(const EdgeID edgeInList,
 
 
 template<class DataTypes>
+void BaseBeamInterpolation<DataTypes>::getBeamAtCurvAbs(const Real& x_input, unsigned int& edgeInList_output, Real& baryCoord_output, unsigned int start)
+{
+    /// lTotalRest = total length of the
+    Real lTotalRest = getRestTotalLength();
+    /// LTotal =  length sum of the beams that are "out"
+    Real LTotal = 0.0;
+
+    const unsigned int edgeListSize = this->d_edgeList.getValue().size();
+
+    /// we find the length of the beam that is "out"
+    for (unsigned int e = start; e < edgeListSize; e++)
+    {
+        LTotal += this->getLength(e);
+    }
+
+    /// x_i = abs_curv from the begining of the instrument
+    Real  x_i = x_input + LTotal - lTotalRest;
+
+    if (x_i < 0.0)
+    {
+        edgeInList_output = start;
+        baryCoord_output = 0;
+        return;
+    }
+
+    /// we compute the x value of each node :the topology (stored in Edge_list) is supposed to be a regular seq of segment
+    Real x = 0;
+
+    for (unsigned int e = start; e < edgeListSize; e++)
+    {
+        x += this->getLength(e);
+        if (x > x_i)
+        {
+            edgeInList_output = e;
+            Real x0 = x - this->getLength(e);
+            baryCoord_output = (x_i - x0) / this->getLength(e);
+            return;
+        }
+    }
+
+    edgeInList_output = edgeListSize - 1;
+    baryCoord_output = 1.0;
+}
+
+
+template<class DataTypes>
 int BaseBeamInterpolation<DataTypes>::computeTransform(const EdgeID edgeInList, const PointID node0Idx, const PointID node1Idx, Transform& global_H_local0, Transform& global_H_local1, const VecCoord& x)
 {
     /// 2. Computes the optional rigid transformation of DOF0_Transform_node0 and DOF1_Transform_node1

--- a/src/BeamAdapter/component/WireBeamInterpolation.h
+++ b/src/BeamAdapter/component/WireBeamInterpolation.h
@@ -168,9 +168,6 @@ public:
     bool isControlled() { return m_isControlled; }
     void setControlled(bool value) { m_isControlled = value; }
 
-    //TODO(dmarchal@cduriez) strange name... seems to be wire based...shouldn't it go to WireBeamInterpolation.
-    virtual void getBeamAtCurvAbs(const Real& x_input, unsigned int& edgeInList_output, Real& baryCoord_output, unsigned int start = 0);
-
 
     SingleLink<WireBeamInterpolation<DataTypes>, sofa::component::engine::WireRestShape<DataTypes>,
     BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> m_restShape; /*! link on an external rest-shape*/

--- a/src/BeamAdapter/component/WireBeamInterpolation.inl
+++ b/src/BeamAdapter/component/WireBeamInterpolation.inl
@@ -292,51 +292,6 @@ typename T::SPtr  WireBeamInterpolation<DataTypes>::create(T* tObj, core::object
 }
 
 
-template<class DataTypes>
-void WireBeamInterpolation<DataTypes>::getBeamAtCurvAbs(const Real& x_input, unsigned int& edgeInList_output, Real& baryCoord_output, unsigned int start)
-{
-    /// lTotalRest = total length of the
-    Real lTotalRest = getRestTotalLength();
-    /// LTotal =  length sum of the beams that are "out"
-    Real LTotal = 0.0;
-
-    const unsigned int edgeListSize = this->d_edgeList.getValue().size();
-
-    /// we find the length of the beam that is "out"
-    for (unsigned int e = start; e < edgeListSize; e++)
-    {
-        LTotal += this->getLength(e);
-    }
-
-    /// x_i = abs_curv from the begining of the instrument
-    Real  x_i = x_input + LTotal - lTotalRest;
-
-    if (x_i < 0.0)
-    {
-        edgeInList_output = start;
-        baryCoord_output = 0;
-        return;
-    }
-
-    /// we compute the x value of each node :the topology (stored in Edge_list) is supposed to be a regular seq of segment
-    Real x = 0;
-
-    for (unsigned int e = start; e < edgeListSize; e++)
-    {
-        x += this->getLength(e);
-        if (x > x_i)
-        {
-            edgeInList_output = e;
-            Real x0 = x - this->getLength(e);
-            baryCoord_output = (x_i - x0) / this->getLength(e);
-            return;
-        }
-    }
-
-    edgeInList_output = edgeListSize - 1;
-    baryCoord_output = 1.0;
-}
-
 } // namespace sofa::component::fem::_wirebeaminterpolation_
 
 

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
@@ -45,7 +45,7 @@
 #include <sofa/component/topology/container/dynamic/EdgeSetTopologyModifier.h>
 
 #include <BeamAdapter/config.h>
-#include <BeamAdapter/component/WireBeamInterpolation.h>
+#include <BeamAdapter/component/BaseBeamInterpolation.h>
 #include <BeamAdapter/component/controller/AdaptiveBeamController.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -74,7 +74,7 @@ using sofa::type::Vec;
 using sofa::type::Mat;
 using sofa::core::topology::BaseMeshTopology;
 using defaulttype::SolidTypes;
-using sofa::component::fem::WireBeamInterpolation;
+using sofa::component::fem::BaseBeamInterpolation;
 using core::MechanicalParams;
 using core::ConstraintParams;
 using core::visual::VisualParams;
@@ -126,7 +126,7 @@ public:
     typedef Mat<12,3,Real> Mat12x3;
     typedef Mat<6,12,Real> Mat6x12;
     typedef Mat<12,6,Real> Mat12x6;
-    typedef WireBeamInterpolation<TIn> BInterpolation;
+    typedef BaseBeamInterpolation<TIn> BInterpolation;
 
     typedef std::pair<unsigned int, Vec3> BeamIdAndBaryCoord;
     struct PosPointDefinition
@@ -160,7 +160,7 @@ public:
 
     AdaptiveBeamMapping(State< In >* from=nullptr,
                         State< Out >* to=nullptr,
-                        WireBeamInterpolation< TIn >* interpolation=nullptr,
+                        BaseBeamInterpolation< TIn >* interpolation=nullptr,
                         bool isSubMapping=false) ;
 
     virtual ~AdaptiveBeamMapping() = default;

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -66,7 +66,7 @@ using core::MechanicalParams;
 
 template <class TIn, class TOut>
 AdaptiveBeamMapping<TIn,TOut>::AdaptiveBeamMapping(State< In >* from, State< Out >* to,
-    WireBeamInterpolation< TIn >* interpolation, bool isSubMapping)
+    BaseBeamInterpolation< TIn >* interpolation, bool isSubMapping)
     : Inherit(from, to)
     , d_useCurvAbs(initData(&d_useCurvAbs,true,"useCurvAbs","true if the curvilinear abscissa of the points remains the same during the simulation if not the curvilinear abscissa moves with adaptivity and the num of segment per beam is always the same"))
     , d_points(initData(&d_points, "points", "defines the mapped points along the beam axis (in beam frame local coordinates)"))
@@ -95,6 +95,7 @@ void AdaptiveBeamMapping< TIn, TOut>::init()
         msg_error() <<"No Beam Interpolation found, the component can not work.";
 
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        return;
     }
 
     if (d_parallelMapping.getValue())
@@ -493,6 +494,9 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJT(const core::ConstraintParams* cpar
 template <class TIn, class TOut>
 void AdaptiveBeamMapping< TIn, TOut>::bwdInit()
 {
+    if (!this->isComponentStateValid())
+        return;
+
     const auto& pts = d_points.getValue();
     const auto ptsSize = pts.size();
 


### PR DESCRIPTION
To be able to use BaseBeamInporlation class in BeamMapping, move one remaining method from wireBeamInterpolation into BaseBeamInterpolation

This should fix scenes crashing on the SOFA dashboard