### PR TITLE
[src] Fix AdaptiveBeamMapping mapping at init with none deployed beam

### DIFF
--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -102,6 +102,8 @@ void AdaptiveBeamMapping< TIn, TOut>::init()
     {
         simulation::MainTaskSchedulerFactory::createInRegistry()->init();
     }
+
+    this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 
@@ -272,6 +274,14 @@ void AdaptiveBeamMapping< TIn, TOut>::apply(const MechanicalParams* mparams, Dat
         }
 
     };
+
+    
+    // HACK for init: In case the number of output points is bigger to the number of distribution, set all points to 0
+    for (int i = m_pointBeamDistribution.size(); i < d_points.getValue().size(); i++)
+    {
+        out[i] = Vec<3, InReal>(0.0, 0.0, 0.0);
+    }
+
 
     const bool multithreading = d_parallelMapping.getValue();
 


### PR DESCRIPTION
In the case of visual mapping:
``` 
    <Node name='VisuGuideCatheter'>
        <MechanicalObject name='dof_visual_GC' />
        <QuadSetTopologyContainer  name='ContainerGC' />
        <QuadSetTopologyModifier />
        <QuadSetGeometryAlgorithms template='Vec3d' />
        <Edge2QuadTopologicalMapping nbPointsOnEachCircle='10' radius='2.06' input='@../../GuideCatheter/GC_mesh' output='@ContainerGC' flipNormals='true'/>

        <AdaptiveBeamMapping  name='VisuMapGuideCath' useCurvAbs='1' printLog='0' interpolation='@../Interpol_GCatheter' input='@../Instrument_DOFs' output='@dof_visual_GC' isMechanical='false'  />
``` 

The Edge2QuadTopologicalMapping  is creating the tubular topology and dofs. But on the other hand, the AdaptiveBeamMapping is looking for the number of beam in the WireBeamInterpolation which is now returning 0, because the beam is not deployed yet. 
So at init the interpolation is not performed in the AdaptiveBeamMapping, therfor the default value computed from Edge2QuadTopologicalMapping  are used.

Then, at first simulation step: 
WireBeamInterpolation return 1 beam, then AdaptiveBeamMapping is interpolating all points and edges around the beam points. All the points that are not linked to the only beam deployed are set to  0.

*Note: In AdaptiveBeamMapping::computeDistribution if only one beam is found, all the other points are associated with beamId =0. Therefore in Apply and ApplyJ we interpolate all points being at X =0 on the beamId = 0 using, projection etc... Which is quite costly to interpolate 0 on 0. 
Moreover at init if we want to use the "normal behavior" with no Beam is define the component crash.

So this fix is not perfect... but the default behavior is not neither.