### PR TITLE
[src] Update RodSection, WireRestShape and All BeamInterpolation to correctly redirect the getters to the Data

### DIFF
--- a/examples/3instruments.scn
+++ b/examples/3instruments.scn
@@ -21,9 +21,9 @@
 
 <!-- ------------------------- INTERVENTIONAL RADIOLOGY INSTRUMENTS (catheter, guidewire, coil)  ------------------------------ -->
 
-	<Node name='topoLines_cath'>
-        <RodStraightSection name="StraightSection" youngModulus="10000" nbEdgesCollis="40" nbEdgesVisu="120" length="600.0" radius='1'/>
-        <RodSpireSection name="SpireSection" youngModulus="10000" nbEdgesCollis="20" nbEdgesVisu="80" length="400.0" spireDiameter="4000.0" spireHeight="0.0" radius='1'/>
+	<Node name='topoLines_cath'> 
+        <RodStraightSection name="StraightSection" youngModulus="10000" massDensity='0.00000155' nbEdgesCollis="40" nbEdgesVisu="120" length="600.0" radius='1'/> <!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->	
+        <RodSpireSection name="SpireSection" youngModulus="10000" massDensity='0.00000155' nbEdgesCollis="20" nbEdgesVisu="80" length="400.0" spireDiameter="4000.0" spireHeight="0.0" radius='1'/>
         
         <WireRestShape template="Rigid3d" name="catheterRestShape" wireMaterials="@StraightSection @SpireSection"/>
     
@@ -33,8 +33,8 @@
 		<MechanicalObject template='Rigid3d' name='dofTopo1' />
 	</Node>
 	<Node name='topoLines_guide'>
-        <RodStraightSection name="StraightSection" youngModulus="10000" nbEdgesCollis="50" nbEdgesVisu="196" length="980.0" radius='0.9'/>
-        <RodSpireSection name="SpireSection" youngModulus="10000" nbEdgesCollis="10" nbEdgesVisu="4" length="20.0" spireDiameter="25" spireHeight="0.0" radius='0.9'/>
+        <RodStraightSection name="StraightSection" youngModulus="10000" massDensity='0.00000155' nbEdgesCollis="50" nbEdgesVisu="196" length="980.0" radius='0.9'/> <!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->
+        <RodSpireSection name="SpireSection" youngModulus="10000" massDensity='0.00000155' nbEdgesCollis="10" nbEdgesVisu="4" length="20.0" spireDiameter="25" spireHeight="0.0" radius='0.9'/>
 		
         <WireRestShape template="Rigid3d" name="GuideRestShape" wireMaterials="@StraightSection @SpireSection"/>
         
@@ -44,8 +44,8 @@
 		<MechanicalObject template='Rigid3d' name='dofTopo2' />
 	</Node>
 	<Node name='topoLines_coils'>
-        <RodStraightSection name="StraightSection" youngModulus="168000" nbEdgesCollis="30" nbEdgesVisu="360" length="540.0" radius='0.1'/>
-        <RodSpireSection name="SpireSection" youngModulus="168000" nbEdgesCollis="30" nbEdgesVisu="40" length="60.0" spireDiameter="7" spireHeight="5.0" radius='0.1'/>
+        <RodStraightSection name="StraightSection" youngModulus="168000" massDensity='0.000021' nbEdgesCollis="30" nbEdgesVisu="360" length="540.0" radius='0.1'/> <!-- platine E = 168000 MPa // 21000 Kg/m3-->	
+        <RodSpireSection name="SpireSection" youngModulus="168000" massDensity='0.000021' nbEdgesCollis="30" nbEdgesVisu="40" length="60.0" spireDiameter="7" spireHeight="5.0" radius='0.1'/>
 		
         <WireRestShape template="Rigid3d" name="CoilRestShape" wireMaterials="@StraightSection @SpireSection"/>
     
@@ -67,14 +67,14 @@
 		/>
 		<MechanicalObject template='Rigid3d' name='DOFs' showIndices='0' ry='-90'/> 
 
-		<WireBeamInterpolation name='InterpolCatheter' WireRestShape='@../topoLines_cath/catheterRestShape' printLog='0'/> 
-		<AdaptiveBeamForceFieldAndMass name='CatheterForceField' interpolation='@InterpolCatheter' massDensity='0.00000155'/> <!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->	
+		<WireBeamInterpolation name='InterpolCatheter' WireRestShape='@../topoLines_cath/catheterRestShape'/> 
+		<AdaptiveBeamForceFieldAndMass name='CatheterForceField' interpolation='@InterpolCatheter'/> 
 
-		<WireBeamInterpolation name='InterpolGuide' WireRestShape='@../topoLines_guide/GuideRestShape' printLog='0'/> 
-		<AdaptiveBeamForceFieldAndMass name='GuideForceField' interpolation='@InterpolGuide' massDensity='0.00000155'/>
+		<WireBeamInterpolation name='InterpolGuide' WireRestShape='@../topoLines_guide/GuideRestShape'/> 
+		<AdaptiveBeamForceFieldAndMass name='GuideForceField' interpolation='@InterpolGuide'/>
 
-		<WireBeamInterpolation name='InterpolCoils' WireRestShape='@../topoLines_coils/CoilRestShape' printLog='0'/> 
-		<AdaptiveBeamForceFieldAndMass name='CoilsForceField' interpolation='@InterpolCoils' massDensity='0.000021'/> <!-- platine E = 168000 MPa // 21000 Kg/m3-->	
+		<WireBeamInterpolation name='InterpolCoils' WireRestShape='@../topoLines_coils/CoilRestShape'/> 
+		<AdaptiveBeamForceFieldAndMass name='CoilsForceField' interpolation='@InterpolCoils'/> 
 
         <BeamAdapterActionController name="AController" interventionController="@IRController" writeMode="0"
             timeSteps="9.1 17.1 17.55 18.05 18.6 19.05 19.55 20.05 20.5 21 21.45 21.9 22.65 23.1 23.55 24.05 24.55 25 25.45 25.95 26.4 27.1 27.55 28.05 28.55 29 29.5 29.95 30.4 30.9 31.4 31.85 32.35 33.05 33.5 34 34.45 34.9 35.4 35.85 36.35 36.8 37.25 37.7 38.2 38.65 39.4 39.85 40.3 40.7 41.2 41.65 42.1 42.55 43 43.4 44.1 44.55 45 45.45 45.9 46.3 46.75 47.2 47.65 48.1 48.55 49 49.65 50.1 50.5 50.9 51.35 51.75 52.2 52.6 53.05 53.5 53.95 54.4 54.85 55.5 55.9 59.1 66.15 66.6 67.05 67.45 67.9 68.35 68.8 69.25 69.65 70.1 70.55 71.2 71.6 72.05 72.5 72.95 73.4 77.6 81.9 87.4 87.75 88.1 88.45 88.75 89.1 89.45 89.75 90.1 90.6 90.9 91.25 91.6 91.95 92.3 92.6 92.95 93.25 93.6 93.95 94.25 94.6 94.95 95.4 95.75 96.1 96.4 96.75 97.05 97.35 97.7 98.05 98.4 98.7 99.15 99.5 99.8 100.15 100.45 100.75 101.1 101.4 101.75 102.05 102.55 102.85 103.2 103.5 103.8 104.1 104.4 104.75 105.05 105.4 105.7 106 106.45 106.75 107.1 107.4 107.7 108 108.35 108.65 108.95 109.25 109.55 110 110.3 110.6 110.9 111.2 111.45 111.75 112.05 112.35 112.65 113.1 113.35 113.65 113.95 114.2 114.5 114.8 115.1 115.35 115.65 116.1 116.35 125.8 128.2 131.6 131.8 132 132.25 132.45 132.65 132.85 133.05 133.3 133.5 133.8 134 134.2 134.4 134.6 134.8 135 135.2 135.4 135.6 135.8 136 136.3 136.5 136.75 136.95 137.15 137.35 137.5 137.7 137.9 138.15 138.3 138.6 138.85 139 139.2 139.4 139.6 139.8 140 140.15 140.35 140.55 140.75 140.95 141.25 141.45 141.65 141.85 142.05 142.25 142.45 142.65 142.85 143.05 143.25 143.45 143.65 143.85 144.15 144.3 144.5 144.7 144.9 145.1 145.3 145.45 145.65 145.95 146.1 146.3 146.5 146.7 146.9 147.1 147.25 147.45 147.65 147.85 148.05 148.25 148.4 148.7 148.9 149.1 149.25 149.45 149.65 149.85 150 150.2 150.35 150.55 150.75 150.9 151.05 151.3 151.45 151.6 151.8 151.95 152.1 152.25 152.4 152.65 152.8 153 153.15 153.3 153.45 153.6 153.75 153.9 154.1 154.25 154.4 154.6 154.75 154.9 155.1 155.25 155.4 155.55 155.7 155.85 156 156.15 156.4 156.55 156.7 156.85 157 157.15 157.3 157.45 157.6 157.75 157.9 158.05 159 160.9 163.4 163.55 163.7 163.85 164.1 164.25 164.4 164.55 164.75 164.9 165.05 165.2 165.35 165.5 165.65 165.8 165.95 166.15 166.35 166.5 166.7 166.85 167 167.15 167.3 167.45 167.65 167.8 167.95 168.1 168.25 168.45 168.6 168.8 169 169.15 169.3 169.45 169.6 169.8 169.95 170.1 170.25 170.4 170.55 170.7 170.95 171.1 171.25 171.4 171.55 171.75 171.9 172.05 172.2 172.45 172.6 172.75 172.9 173.1 173.25 185.8"

--- a/examples/3instruments_collis.scn
+++ b/examples/3instruments_collis.scn
@@ -38,8 +38,8 @@
 <!-- ------------------------- INTERVENTIONAL RADIOLOGY INSTRUMENTS (catheter, guidewire, coil)  ------------------------------ -->
 
 	<Node name="topoLines_cath">
-        <RodStraightSection name="StraightSection" youngModulus="10000" radius="1" nbEdgesCollis="40" nbEdgesVisu="220" length="600.0"/>
-        <RodSpireSection name="SpireSection" youngModulus="10000" radius="1" nbEdgesCollis="10" nbEdgesVisu="80" length="400.0" spireDiameter="4000.0" spireHeight="0.0"/>        
+        <RodStraightSection name="StraightSection" youngModulus="10000" massDensity="0.00000155" radius="1" nbEdgesCollis="40" nbEdgesVisu="220" length="600.0"/><!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->	
+        <RodSpireSection name="SpireSection" youngModulus="10000" massDensity="0.00000155" radius="1" nbEdgesCollis="10" nbEdgesVisu="80" length="400.0" spireDiameter="4000.0" spireHeight="0.0"/>        
         
         <WireRestShape template="Rigid3d" name="catheterRestShape" wireMaterials="@StraightSection @SpireSection"/> <!-- silicone -->		
     
@@ -49,8 +49,8 @@
 		<MechanicalObject template="Rigid3d" name="dofTopo1" />
 	</Node>
 	<Node name="topoLines_guide">
-        <RodStraightSection name="StraightSection" youngModulus="10000" radius="0.9" nbEdgesCollis="50" nbEdgesVisu="196" length="980.0"/>
-        <RodSpireSection name="SpireSection" youngModulus="10000" radius="0.9" nbEdgesCollis="10" nbEdgesVisu="4" length="20.0" spireDiameter="25" spireHeight="0.0"/>        
+        <RodStraightSection name="StraightSection" youngModulus="10000" massDensity="0.00000155" radius="0.9" nbEdgesCollis="50" nbEdgesVisu="196" length="980.0"/> <!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->	
+        <RodSpireSection name="SpireSection" youngModulus="10000" massDensity="0.00000155" radius="0.9" nbEdgesCollis="10" nbEdgesVisu="4" length="20.0" spireDiameter="25" spireHeight="0.0"/>        
 		
         <WireRestShape template="Rigid3d" name="GuideRestShape" wireMaterials="@StraightSection @SpireSection"/>
     
@@ -60,8 +60,8 @@
 		<MechanicalObject template="Rigid3d" name="dofTopo2" />
 	</Node>
 	<Node name="topoLines_coils">
-        <RodStraightSection name="StraightSection" youngModulus="168000" radius="0.1" nbEdgesCollis="30" nbEdgesVisu="360" length="540.0"/>
-        <RodSpireSection name="SpireSection" youngModulus="168000" radius="0.1" nbEdgesCollis="30" nbEdgesVisu="40" length="60.0" spireDiameter="7" spireHeight="5.0"/>        
+        <RodStraightSection name="StraightSection" youngModulus="168000" massDensity="0.000021" radius="0.1" nbEdgesCollis="30" nbEdgesVisu="360" length="540.0"/> <!-- platine E = 168000 MPa // 21000 Kg/m3-->
+        <RodSpireSection name="SpireSection" youngModulus="168000" massDensity="0.000021" radius="0.1" nbEdgesCollis="30" nbEdgesVisu="40" length="60.0" spireDiameter="7" spireHeight="5.0"/>        
 		
         <WireRestShape template="Rigid3d" name="CoilRestShape" wireMaterials="@StraightSection @SpireSection"/>
         
@@ -83,14 +83,14 @@
 		/>
 		<MechanicalObject template="Rigid3d" name="DOFs" showIndices="0" ry="-90"/> 
 
-		<WireBeamInterpolation name="InterpolCatheter" WireRestShape="@../topoLines_cath/catheterRestShape" printLog="0"/> 
-		<AdaptiveBeamForceFieldAndMass name="CatheterForceField" interpolation="@InterpolCatheter" massDensity="0.00000155"/> <!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->	
+		<WireBeamInterpolation name="InterpolCatheter" WireRestShape="@../topoLines_cath/catheterRestShape"/> 
+		<AdaptiveBeamForceFieldAndMass name="CatheterForceField" interpolation="@InterpolCatheter" /> 
 
-		<WireBeamInterpolation name="InterpolGuide" WireRestShape="@../topoLines_guide/GuideRestShape" printLog="0"/> 
-		<AdaptiveBeamForceFieldAndMass name="GuideForceField" interpolation="@InterpolGuide" massDensity="0.00000155"/> 	
+		<WireBeamInterpolation name="InterpolGuide" WireRestShape="@../topoLines_guide/GuideRestShape"/> 
+		<AdaptiveBeamForceFieldAndMass name="GuideForceField" interpolation="@InterpolGuide"/> 	
 
-		<WireBeamInterpolation name="InterpolCoils" WireRestShape="@../topoLines_coils/CoilRestShape" printLog="0"/> 
-		<AdaptiveBeamForceFieldAndMass name="CoilsForceField" interpolation="@InterpolCoils" massDensity="0.000021"/> <!-- platine E = 168000 MPa // 21000 Kg/m3-->	
+		<WireBeamInterpolation name="InterpolCoils" WireRestShape="@../topoLines_coils/CoilRestShape"/> 
+		<AdaptiveBeamForceFieldAndMass name="CoilsForceField" interpolation="@InterpolCoils"/> 	
 
         <BeamAdapterActionController name="AController" interventionController="@IRController" writeMode="0"
             timeSteps="4.3 7.5 7.65 7.85 8.05 8.25 8.45 8.7 8.9 9.2 9.4 9.6 9.8 10 10.25 10.4 10.65 10.85 11.05 11.25 11.45 11.7 11.95 12.2 12.4 12.6 12.8 13 13.2 13.4 13.6 13.85 14.05 14.35 14.55 14.75 14.95 15.15 15.35 15.5 15.7 15.85 16.1 16.25 16.4 16.55 16.7 16.85 17 17.2 17.35 17.55 17.7 17.85 17.95 18.1 18.25 18.35 18.5 18.65 18.85 19 19.2 19.35 19.45 19.6 19.75 19.95 20.1 20.25 20.4 20.55 20.7 20.85 21.35 22.35 23.05 23.65 25 25.1 25.2 25.35 25.5 25.65 25.8 29 30.5 31.9 33.85 33.95 34.1 34.2 34.3 34.45 34.55 34.65 34.8 34.95 35.05 35.15 35.3 35.4 35.5 35.6 35.7 35.8 35.95 36.1 36.2 36.3 36.45 36.5 36.65 36.75 36.9 37 37.1 37.2 37.3 37.45 37.55 37.65 37.75 37.85 38 38.1 38.2 38.3 38.45 38.55 38.65 38.8 38.9 39.05 39.15 39.3 39.4 39.55 39.65 39.7 39.85 39.9 40.1 40.2 40.3 40.4 40.55 40.65 40.8 40.9 41.05 41.15 41.3 41.4 41.6 41.7 41.8 41.95 42 42.1 42.2 42.35 42.45 42.6 42.65 42.8 42.95 43.05 43.2 43.3 43.45 43.55 43.65 43.8 43.9 44 44.15 44.25 44.4 44.55 45.5 47.35 47.45 47.55 47.65 47.7 47.8 47.9 48 50.4 52.35 52.45 52.55 52.65 52.75 52.9 53 53.1 53.2 53.3 53.4 54.35 56.05 56.15 56.2 56.3 56.4 56.5 56.6 56.65 56.7 57.95 58.6 59.45 59.55 59.6 59.7 59.8 59.9 59.95 60.05 60.1 60.15 60.25 60.3 60.4 60.5 60.6 60.65 60.75 60.85 60.95 61 61.1 61.15 61.2 61.3 61.4 61.5 61.65 61.75 61.85 62 62.15 62.25 62.35 62.45 62.55 62.65 62.75 62.85 62.9 63 63.05 63.15 63.2 63.25 63.35 63.4 63.5 63.6 63.7 63.75 63.85 63.95 64.05 64.2 64.3 64.35 64.45 64.55 64.6 64.7 64.8 64.9 65 65.1 65.2 65.3 65.45 65.55 65.65 65.75 65.8 65.9 72.15 73.6 73.7 73.8 73.85 73.95 74 74.1 74.25 74.35 74.45 74.55 75.4 76.1 76.7 77.65 79.85 82 82.85 84.25 84.35 84.45 84.55 84.65 84.75 84.8 84.9 84.95 85.1 85.2 85.3 85.4 85.5 85.6 85.7 85.8 85.9 86 86.1 86.2 86.3 86.4 86.45 86.55 86.65 86.75 86.8 86.9 87 87.15 87.25 87.3 87.4 87.5 87.6 87.7 87.75 87.85 87.95 88 88.1 88.25 88.35 88.45 88.55 88.65 88.75 88.85 88.95 89.05 89.15 89.25 89.35 89.5 89.6 89.75 89.85 89.95 90.05 90.15 90.75 92.4 92.5 92.6 92.7 94.45 97.25 98.1 99.3 99.4 99.5 99.55 99.65 99.7 99.8 99.85 99.95 100.05 100.15 100.2 100.3 100.35 100.45 100.5 100.55 100.65 100.7 100.8 100.85 100.95 101.05 101.15 101.2 101.25 101.35 101.4 101.5 101.55 101.65 101.7 101.75 101.85 101.9 102 102.05 102.15 102.2 102.3 102.35 102.45 102.5 102.6 102.65 102.7 102.8 102.85 102.95 103.05 103.1 103.2 103.25 103.35 103.4 103.5 103.55 103.65 103.7 103.75 103.85 103.95 104.05 104.1 104.2 104.25 104.3 104.4 104.45 104.55 104.6 104.7 104.75 104.85 104.95 105 105.1 105.15 105.25 105.3 105.4 105.45 105.55 105.6 105.65 105.75 105.85 105.95 106 106.05 106.15 106.2 106.3 106.35 106.45 106.5 106.6 106.65 106.75 106.85 106.9 107 107.05 107.15 107.2 107.3 107.35 107.45 107.5 107.6 107.7 107.75 107.85 107.9 107.95 108.05 108.1 108.2 108.25 108.3 108.4 108.45 108.55 108.65 108.7 108.8 108.85 108.95 109 109.1 109.15 109.25 109.3 109.35 109.45 109.55 109.65 109.7 109.8 109.85 109.9 110 110.05 110.15 110.2 110.3 110.35 110.45 110.55 110.6 110.7 110.75 110.8 110.9 110.95 111.05 111.1 111.2 111.25 111.35 111.45 111.5 111.6 111.65 111.75 111.8 111.9 111.95 112.05 112.1 112.2 112.25 112.35 112.4 112.5 112.55 112.65 112.7 112.75 112.85 112.9 113 113.1 113.15 113.2 113.3 113.4 113.45 113.55 113.6 113.65 113.75 113.8 113.9 113.95 114 114.1 114.2 114.25 114.35 114.4 114.5 114.6 114.65 114.75 114.85 114.9 114.95 115.05 115.1 115.2 115.3 115.35 115.4 115.5 115.6 115.65 115.75 115.8 115.9 116 116.05 116.1 116.2 116.3 116.4 116.5 116.55 116.6 116.7 116.8 116.85 116.95 117.05 117.1 117.15 117.25 117.35 117.45 117.5 117.6 117.65 117.75 117.85 117.9 117.95 118.05 118.15 118.25 118.35 118.4 118.5 122.65"

--- a/examples/SingleBeamDeployment.scn
+++ b/examples/SingleBeamDeployment.scn
@@ -15,8 +15,8 @@
     <DefaultVisualManagerLoop />
 
     <Node name="EdgeTopology">
-        <RodStraightSection name="StraightSection" youngModulus="20000" radius="0.9" nbEdgesCollis="30" nbEdgesVisu="196" length="980.0"/>
-        <RodSpireSection name="SpireSection" youngModulus="20000" radius="0.9" nbEdgesCollis="5" nbEdgesVisu="4" length="20.0" spireDiameter="25" spireHeight="0.0"/>
+        <RodStraightSection name="StraightSection" youngModulus="20000" radius="0.9" massDensity="0.00000155" nbEdgesCollis="30" nbEdgesVisu="196" length="980.0"/>
+        <RodSpireSection name="SpireSection" youngModulus="20000" radius="0.9" massDensity="0.00000155" nbEdgesCollis="5" nbEdgesVisu="4" length="20.0" spireDiameter="25" spireHeight="0.0"/>
         
         <WireRestShape template="Rigid3d" name="BeamRestShape" printLog="1" wireMaterials="@StraightSection @SpireSection"/>
         <EdgeSetTopologyContainer name="meshLinesBeam"/>
@@ -34,7 +34,7 @@
         <MechanicalObject template="Rigid3d" name="DOFs Container" ry="-90" /> 
 
         <WireBeamInterpolation name="BeamInterpolation" WireRestShape="@../EdgeTopology/BeamRestShape" />
-        <AdaptiveBeamForceFieldAndMass name="BeamForceField"  massDensity="0.00000155" interpolation="@BeamInterpolation"/>
+        <AdaptiveBeamForceFieldAndMass name="BeamForceField" interpolation="@BeamInterpolation"/>
         <InterventionalRadiologyController name="DeployController" template="Rigid3d" instruments="BeamInterpolation"
                                     startingPos="0 0 0 0 0 0 1" xtip="0 0 0" printLog="1" 
                                     rotationInstrument="0 0 0" step="0.5" speed="0.5" 

--- a/examples/SingleBeamDeploymentCollision.scn
+++ b/examples/SingleBeamDeploymentCollision.scn
@@ -32,8 +32,8 @@
 
 
     <Node name="EdgeTopology">
-        <RodStraightSection name="StraightSection" youngModulus="20000" radius="0.9" massDensity="0.1" poissonRatio="0.3" nbEdgesCollis="50" nbEdgesVisu="200" length="980.0"/>
-        <RodSpireSection name="SpireSection" youngModulus="20000" radius="0.9" massDensity="0.1" poissonRatio="0.3" nbEdgesCollis="10" nbEdgesVisu="200" length="20.0" spireDiameter="25" spireHeight="0.0"/>        
+        <RodStraightSection name="StraightSection" youngModulus="20000" radius="0.9" massDensity="0.00000155" poissonRatio="0.3" nbEdgesCollis="50" nbEdgesVisu="200" length="980.0"/>
+        <RodSpireSection name="SpireSection" youngModulus="20000" radius="0.9" massDensity="0.00000155" poissonRatio="0.3" nbEdgesCollis="10" nbEdgesVisu="200" length="20.0" spireDiameter="25" spireHeight="0.0"/>        
         
         <WireRestShape template="Rigid3d" name="BeamRestShape" wireMaterials="@StraightSection @SpireSection"/>
     
@@ -52,7 +52,7 @@
         <MechanicalObject template="Rigid3d" name="DOFs Container" ry="-90" /> 
 
         <WireBeamInterpolation name="BeamInterpolation" WireRestShape="@../EdgeTopology/BeamRestShape"/>
-        <AdaptiveBeamForceFieldAndMass name="BeamForceField"  massDensity="0.00000155" interpolation="@BeamInterpolation"/>
+        <AdaptiveBeamForceFieldAndMass name="BeamForceField" interpolation="@BeamInterpolation"/>
         <InterventionalRadiologyController name="DeployController" template="Rigid3d" instruments="BeamInterpolation"
                                     startingPos="0 0 0 0 0 0 1" xtip="0 0 0" printLog="1" 
                                     rotationInstrument="0 0 0" step="5" speed="5" 

--- a/src/BeamAdapter/component/BaseBeamInterpolation.h
+++ b/src/BeamAdapter/component/BaseBeamInterpolation.h
@@ -134,6 +134,8 @@ public:
     virtual void getSplineRestTransform(unsigned int edgeInList, Transform& local_H_local0_rest, Transform& local_H_local1_rest) = 0;
     virtual void getInterpolationParam(unsigned int edgeInList, Real& _L, Real& _A, Real& _Iy, Real& _Iz,
         Real& _Asy, Real& _Asz, Real& J) = 0;
+    virtual void getMechanicalParam(int beamId, Real& youngModulus, Real& cPoisson, Real& massDensity) = 0;
+
     virtual const BeamSection& getBeamSection(int edgeIndex) = 0;
     virtual void getBeamAtCurvAbs(const Real& x_input, unsigned int& edgeInList_output, Real& baryCoord_output, unsigned int start = 0);
 

--- a/src/BeamAdapter/component/BaseBeamInterpolation.h
+++ b/src/BeamAdapter/component/BaseBeamInterpolation.h
@@ -124,7 +124,6 @@ public:
     void addCollisionOnBeam(unsigned int b);
     void clearCollisionOnBeam();
 
-    virtual void getYoungModulusAtX(int beamId, Real& x_curv, Real& youngModulus, Real& cPoisson) = 0;
     virtual void getSamplingParameters(type::vector<Real>& xP_noticeable,
         type::vector<int>& nbP_density) = 0;
     virtual void getNumberOfCollisionSegment(Real& dx, unsigned int& numLines) = 0;
@@ -132,11 +131,15 @@ public:
 
     virtual void getCurvAbsAtBeam(const unsigned int& edgeInList_input, const Real& baryCoord_input, Real& x_output) = 0;
     virtual void getSplineRestTransform(unsigned int edgeInList, Transform& local_H_local0_rest, Transform& local_H_local1_rest) = 0;
-    virtual void getInterpolationParam(unsigned int edgeInList, Real& _L, Real& _A, Real& _Iy, Real& _Iz,
-        Real& _Asy, Real& _Asz, Real& J) = 0;
-    virtual void getMechanicalParam(int beamId, Real& youngModulus, Real& cPoisson, Real& massDensity) = 0;
+    
+    /// Returns the BeamSection @sa m_beamSection corresponding to the given beam
+    virtual const BeamSection& getBeamSection(sofa::Index beamId) = 0;
+    /// Returns the BeamSection data depending on the beam position at the given beam, similar to @getBeamSection
+    virtual void getInterpolationParameters(sofa::Index beamId, Real& _L, Real& _A, Real& _Iy, Real& _Iz, Real& _Asy, Real& _Asz, Real& J) = 0;
+    /// Returns the Young modulus, Poisson's ratio and massDensity coefficient of the section at the given curvilinear abscissa
+    virtual void getMechanicalParameters(sofa::Index beamId, Real& youngModulus, Real& cPoisson, Real& massDensity) = 0;
 
-    virtual const BeamSection& getBeamSection(int edgeIndex) = 0;
+
     virtual void getBeamAtCurvAbs(const Real& x_input, unsigned int& edgeInList_output, Real& baryCoord_output, unsigned int start = 0);
 
     int computeTransform(const EdgeID edgeInList, Transform& global_H_local0, Transform& global_H_local1, const VecCoord& x);

--- a/src/BeamAdapter/component/BeamInterpolation.h
+++ b/src/BeamAdapter/component/BeamInterpolation.h
@@ -189,6 +189,8 @@ public:
     void getCollisionSampling(Real &dx, const Real& x_localcurv_abs) override;
     void getNumberOfCollisionSegment(Real &dx, unsigned int &numLines) override;
     void getYoungModulusAtX(int beamId,Real& x_curv, Real& youngModulus, Real& cPoisson) override;
+    void getMechanicalParam(int beamId, Real& youngModulus, Real& cPoisson, Real& massDensity) override;
+
     void setTransformBetweenDofAndNode(int beam, const Transform &DOF_H_Node, unsigned int zeroORone );
     void getSplineRestTransform(unsigned int edgeInList, Transform &local_H_local0_rest, Transform &local_H_local1_rest) override;
 

--- a/src/BeamAdapter/component/BeamInterpolation.h
+++ b/src/BeamAdapter/component/BeamInterpolation.h
@@ -140,9 +140,13 @@ public:
     bool verifyTopology();
     void computeCrossSectionInertiaMatrix();
 
-    void getInterpolationParam(unsigned int edgeInList, Real &_L, Real &_A, Real &_Iy , Real &_Iz,
+    const BeamSection& getBeamSection(sofa::Index beamId) override { 
+        SOFA_UNUSED(beamId);
+        return this->m_constantSection; 
+    }
+    void getInterpolationParameters(sofa::Index beamId, Real &_L, Real &_A, Real &_Iy , Real &_Iz,
                                Real &_Asy, Real &_Asz, Real &J) override;
-
+    void getMechanicalParameters(sofa::Index beamId, Real& youngModulus, Real& cPoisson, Real& massDensity) override;
 
     void getTangentUsingSplinePoints(unsigned int edgeInList, const Real& baryCoord, const ConstVecCoordId &vecXId, Vec3& t );
 
@@ -150,7 +154,7 @@ public:
     /// computeActualLength => given the 4 control points of the spline, it provides an estimate of the length (using gauss points integration)
    
 
-    const BeamSection &getBeamSection(int /*edgeIndex*/ ) override {return this->m_constantSection;}
+    
 
     virtual void getCurvAbsAtBeam(const unsigned int& edgeInList_input, const Real& baryCoord_input, Real& x_output) {}
     virtual void getBeamAtCurvAbs(const Real& x_input, unsigned int& edgeInList_output, Real& baryCoord_output, unsigned int start = 0) {}
@@ -188,8 +192,6 @@ public:
     Real getRestTotalLength() override;
     void getCollisionSampling(Real &dx, const Real& x_localcurv_abs) override;
     void getNumberOfCollisionSegment(Real &dx, unsigned int &numLines) override;
-    void getYoungModulusAtX(int beamId,Real& x_curv, Real& youngModulus, Real& cPoisson) override;
-    void getMechanicalParam(int beamId, Real& youngModulus, Real& cPoisson, Real& massDensity) override;
 
     void setTransformBetweenDofAndNode(int beam, const Transform &DOF_H_Node, unsigned int zeroORone );
     void getSplineRestTransform(unsigned int edgeInList, Transform &local_H_local0_rest, Transform &local_H_local1_rest) override;

--- a/src/BeamAdapter/component/BeamInterpolation.inl
+++ b/src/BeamAdapter/component/BeamInterpolation.inl
@@ -416,6 +416,15 @@ void BeamInterpolation<DataTypes>::getYoungModulusAtX(int beamId, Real& /*x_curv
 }
 
 
+template<class DataTypes>
+void BeamInterpolation<DataTypes>::getMechanicalParam(int beamId, Real& youngModulus, Real& cPoisson, Real& massDensity)
+{
+    Real xcurv;
+    return getYoungModulusAtX(beamId, xcurv, youngModulus, cPoisson);
+}
+
+
+
 template <class DataTypes>
 void BeamInterpolation<DataTypes>::setTransformBetweenDofAndNode(int beam, const Transform &DOF_H_Node, unsigned int zeroORone )
 {
@@ -500,6 +509,7 @@ void BeamInterpolation<DataTypes>::getInterpolationParam(unsigned int edgeInList
     _Asz=bS._Asz;
     _J=bS._J;
 }
+
 
 
 

--- a/src/BeamAdapter/component/BeamInterpolation.inl
+++ b/src/BeamAdapter/component/BeamInterpolation.inl
@@ -395,32 +395,44 @@ void BeamInterpolation<DataTypes>::getNumberOfCollisionSegment(Real &dx, unsigne
     dx = getRestTotalLength()/numLines;
 }
 
-template <class DataTypes>
-void BeamInterpolation<DataTypes>::getYoungModulusAtX(int beamId, Real& /*x_curv*/, Real& youngModulus, Real& cPoisson)
+
+template<class DataTypes>
+void BeamInterpolation<DataTypes>::getInterpolationParameters(sofa::Index beamId, Real& _L, Real& _A, Real& _Iy,
+    Real& _Iz, Real& _Asy, Real& _Asz, Real& _J)
+{
+    /// get the length of the beam:
+    _L = this->d_lengthList.getValue()[beamId];
+    _A = m_constantSection._A;
+    _Iy = m_constantSection._Iy;
+    _Iz = m_constantSection._Iz;
+    _Asy = m_constantSection._Asy;
+    _Asz = m_constantSection._Asz;
+    _J = m_constantSection._J;
+}
+
+
+template<class DataTypes>
+void BeamInterpolation<DataTypes>::getMechanicalParameters(sofa::Index beamId, Real& youngModulus, Real& cPoisson, Real& massDensity)
 {
     const auto& defaultYoungModuli = d_defaultYoungModulus.getValue();
     if (beamId < int(defaultYoungModuli.size())) {
 
         youngModulus = defaultYoungModuli[beamId];
-    } else {
+    }
+    else {
         youngModulus = m_defaultYoungModulus;
     }
-    
+
     const auto& poissonRatios = d_poissonRatio.getValue();
     if (beamId < int(poissonRatios.size())) {
 
-        cPoisson     = poissonRatios[beamId];
-    } else {
-        cPoisson     = m_defaultPoissonRatio;
+        cPoisson = poissonRatios[beamId];
     }
-}
+    else {
+        cPoisson = m_defaultPoissonRatio;
+    }
 
-
-template<class DataTypes>
-void BeamInterpolation<DataTypes>::getMechanicalParam(int beamId, Real& youngModulus, Real& cPoisson, Real& massDensity)
-{
-    Real xcurv;
-    return getYoungModulusAtX(beamId, xcurv, youngModulus, cPoisson);
+    //TODO: massDensity??
 }
 
 
@@ -492,27 +504,6 @@ void BeamInterpolation<DataTypes>::getSplineRestTransform(unsigned int edgeInLis
             msg_error() <<"This component needs a context mechanical state if the 'straight' parameter is set to false." ;
     }
 }
-
-
-template<class DataTypes>
-void BeamInterpolation<DataTypes>::getInterpolationParam(unsigned int edgeInList, Real &_L, Real &_A, Real &_Iy ,
-                                                         Real &_Iz, Real &_Asy, Real &_Asz, Real &_J)
-{
-    /// get the length of the beam:
-    _L = this->d_lengthList.getValue()[edgeInList];
-
-    BeamSection bS = getBeamSection(edgeInList);
-    _A=bS._A;
-    _Iy=bS._Iy;
-    _Iz=bS._Iz;
-    _Asy=bS._Asy;
-    _Asz=bS._Asz;
-    _J=bS._J;
-}
-
-
-
-
 
 
 template<class DataTypes>

--- a/src/BeamAdapter/component/WireBeamInterpolation.h
+++ b/src/BeamAdapter/component/WireBeamInterpolation.h
@@ -138,6 +138,13 @@ public:
     }
 
 
+    void getMechanicalParam(int beamId, Real& youngModulus, Real& cPoisson, Real& massDensity) override
+    {
+        Real x_curv = 0;
+        this->getAbsCurvXFromBeam(beamId, x_curv);
+        this->m_restShape->getMechanicalParamAtX(x_curv, youngModulus, cPoisson, massDensity);
+    }
+
     virtual void getRestTransform(unsigned int edgeInList, Transform &local0_H_local1_rest);
     
     void getCurvAbsAtBeam(const unsigned int& edgeInList_input, const Real& baryCoord_input, Real& x_output) override;

--- a/src/BeamAdapter/component/WireBeamInterpolation.h
+++ b/src/BeamAdapter/component/WireBeamInterpolation.h
@@ -131,27 +131,15 @@ public:
     }
 
 
-    void getYoungModulusAtX(int beamId,Real& x_curv, Real& youngModulus, Real& cPoisson) override
-    {
-        this->getAbsCurvXFromBeam(beamId, x_curv);
-        this->m_restShape->getYoungModulusAtX(x_curv, youngModulus, cPoisson);
-    }
-
-
-    void getMechanicalParam(int beamId, Real& youngModulus, Real& cPoisson, Real& massDensity) override
-    {
-        Real x_curv = 0;
-        this->getAbsCurvXFromBeam(beamId, x_curv);
-        this->m_restShape->getMechanicalParamAtX(x_curv, youngModulus, cPoisson, massDensity);
-    }
-
     virtual void getRestTransform(unsigned int edgeInList, Transform &local0_H_local1_rest);
     
     void getCurvAbsAtBeam(const unsigned int& edgeInList_input, const Real& baryCoord_input, Real& x_output) override;
     void getSplineRestTransform(unsigned int edgeInList, Transform &local_H_local0_rest, Transform &local_H_local1_rest) override;
-    void getInterpolationParam(unsigned int edgeInList, Real& _L, Real& _A, Real& _Iy, Real& _Iz,
-        Real& _Asy, Real& _Asz, Real& _J) override;
-    const BeamSection& getBeamSection(int edgeIndex) override;
+    
+    const BeamSection& getBeamSection(sofa::Index beamId) override;
+    void getInterpolationParameters(sofa::Index beamId, Real& _L, Real& _A, Real& _Iy, Real& _Iz, Real& _Asy, Real& _Asz, Real& _J) override;
+    void getMechanicalParameters(sofa::Index, Real& youngModulus, Real& cPoisson, Real& massDensity) override;
+    
     bool getApproximateCurvAbs(const Vec3& x_input, const VecCoord& x,  Real& x_output);	// Project a point on the segments, return false if cant project
 
     

--- a/src/BeamAdapter/component/WireBeamInterpolation.inl
+++ b/src/BeamAdapter/component/WireBeamInterpolation.inl
@@ -183,7 +183,7 @@ const BeamSection& WireBeamInterpolation<DataTypes>::getBeamSection(int edgeInde
     this->getAbsCurvXFromBeam(edgeIndex, x_curv);
 
     auto restShape = this->m_restShape.get();
-    return restShape->getBeamSection(x_curv);
+    return restShape->getBeamSectionAtX(x_curv);
 }
 
 template<class DataTypes>

--- a/src/BeamAdapter/component/WireBeamInterpolation.inl
+++ b/src/BeamAdapter/component/WireBeamInterpolation.inl
@@ -163,28 +163,38 @@ void WireBeamInterpolation<DataTypes>::getCurvAbsAtBeam(const unsigned int &edge
 
 
 template<class DataTypes>
-void WireBeamInterpolation<DataTypes>::getInterpolationParam(unsigned int edgeInList, Real& _L, Real& _A, Real& _Iy, Real& _Iz,
-    Real& _Asy, Real& _Asz, Real& _J)
-{
-    _L = this->d_lengthList.getValue()[edgeInList];
-    Real _rho;
-    Real x_curv = 0;
-    this->getAbsCurvXFromBeam(edgeInList, x_curv);
-
-    auto restShape = this->m_restShape.get();
-    restShape->getInterpolationParam(x_curv, _rho, _A, _Iy, _Iz, _Asy, _Asz, _J);
-}
-
-
-template<class DataTypes>
-const BeamSection& WireBeamInterpolation<DataTypes>::getBeamSection(int edgeIndex)
+const BeamSection& WireBeamInterpolation<DataTypes>::getBeamSection(sofa::Index beamId)
 {
     Real x_curv = 0;
-    this->getAbsCurvXFromBeam(edgeIndex, x_curv);
+    this->getAbsCurvXFromBeam(beamId, x_curv);
 
     auto restShape = this->m_restShape.get();
     return restShape->getBeamSectionAtX(x_curv);
 }
+
+
+template<class DataTypes>
+void WireBeamInterpolation<DataTypes>::getInterpolationParameters(sofa::Index beamId, Real& _L, Real& _A, Real& _Iy, Real& _Iz,
+    Real& _Asy, Real& _Asz, Real& _J)
+{
+    _L = this->d_lengthList.getValue()[beamId];
+    Real _rho;
+    Real x_curv = 0;
+    this->getAbsCurvXFromBeam(beamId, x_curv);
+
+    auto restShape = this->m_restShape.get();
+    restShape->getInterpolationParametersAtX(x_curv, _A, _Iy, _Iz, _Asy, _Asz, _J);
+}
+
+
+template<class DataTypes>
+void WireBeamInterpolation<DataTypes>::getMechanicalParameters(sofa::Index beamId, Real& youngModulus, Real& cPoisson, Real& massDensity)
+{
+    Real x_curv = 0;
+    this->getAbsCurvXFromBeam(beamId, x_curv);
+    this->m_restShape->getMechanicalParametersAtX(x_curv, youngModulus, cPoisson, massDensity);
+}
+
 
 template<class DataTypes>
 bool WireBeamInterpolation<DataTypes>::getApproximateCurvAbs(const Vec3& x_input, const VecCoord& x, Real& x_output)

--- a/src/BeamAdapter/component/engine/WireRestShape.h
+++ b/src/BeamAdapter/component/engine/WireRestShape.h
@@ -96,8 +96,13 @@ public:
      /// This function gives the mass density and the BeamSection data depending on the beam position
      void getInterpolationParam(const Real& x_curv, Real &_rho, Real &_A, Real &_Iy , Real &_Iz, Real &_Asy, Real &_Asz, Real &_J) const;
 
-     /// This function returns the BeamSection data depending on the beam position
-     const BeamSection& getBeamSection(const Real& x_curv) const;
+
+     /// Returns the Young modulus, Poisson's and massDensity coefficient of the section at the given curvilinear abscissa
+     void getMechanicalParamAtX(const Real& x_curv, Real& youngModulus, Real& cPoisson, Real& massDensity) const;
+
+     /// Returns the BeamSection @sa m_beamSection corresponding to the given curvilinear abscissa
+     [[nodiscard]] const BeamSection& getBeamSectionAtX(const Real& x_curv) const;
+
 
      /**
       * This function provides a type::vector with the curviliar abscissa of the noticeable point(s) 

--- a/src/BeamAdapter/component/engine/WireRestShape.h
+++ b/src/BeamAdapter/component/engine/WireRestShape.h
@@ -90,18 +90,14 @@ public:
      /// This function is called by the force field to evaluate the rest position of each beam
      void getRestTransformOnX(Transform &global_H_local, const Real &x);
 
-     /// This function gives the Young modulus and Poisson's coefficient of the beam depending on the beam position
-     void getYoungModulusAtX(const Real& x_curv, Real& youngModulus, Real& cPoisson) const;
-
-     /// This function gives the mass density and the BeamSection data depending on the beam position
-     void getInterpolationParam(const Real& x_curv, Real &_rho, Real &_A, Real &_Iy , Real &_Iz, Real &_Asy, Real &_Asz, Real &_J) const;
-
-
-     /// Returns the Young modulus, Poisson's and massDensity coefficient of the section at the given curvilinear abscissa
-     void getMechanicalParamAtX(const Real& x_curv, Real& youngModulus, Real& cPoisson, Real& massDensity) const;
-
-     /// Returns the BeamSection @sa m_beamSection corresponding to the given curvilinear abscissa
+     /// Returns the BeamSection @sa m_beamSection corresponding to the given curvilinear abscissa, will call @sa BaseRodSectionMaterial::getBeamSection
      [[nodiscard]] const BeamSection& getBeamSectionAtX(const Real& x_curv) const;
+
+     /// Returns the BeamSection data depending on the beam position at the given curvilinear abscissa, will call @sa BaseRodSectionMaterial::getInterpolationParameters
+     void getInterpolationParametersAtX(const Real& x_curv, Real &_A, Real &_Iy , Real &_Iz, Real &_Asy, Real &_Asz, Real &_J) const;
+
+     /// Returns the Young modulus, Poisson's ratio and massDensity coefficient of the section at the given curvilinear abscissa, will call @sa BaseRodSectionMaterial::getMechanicalParameters
+     void getMechanicalParametersAtX(const Real& x_curv, Real& youngModulus, Real& cPoisson, Real& massDensity) const;
 
 
      /**

--- a/src/BeamAdapter/component/engine/WireRestShape.inl
+++ b/src/BeamAdapter/component/engine/WireRestShape.inl
@@ -258,45 +258,6 @@ void WireRestShape<DataTypes>::getRestTransformOnX(Transform &global_H_local, co
 
 
 template <class DataTypes>
-void WireRestShape<DataTypes>::getYoungModulusAtX(const Real& x_curv, Real& youngModulus, Real& cPoisson) const
-{
-    const Real x_used = x_curv - Real(EPSILON);
-    const type::vector<Real>& keyPts = d_keyPoints.getValue();
-
-    // Depending on the position of the beam, determine the corresponding section material and returning its Young modulus
-    for (sofa::Size i = 1; i < keyPts.size(); ++i)
-    {
-        if (x_used <= keyPts[i])
-        {
-            return l_sectionMaterials.get(i - 1)->getYoungModulusAtX(youngModulus, cPoisson);
-        }
-    }
-
-    msg_error() << " problem in getYoungModulusAtX : x_curv " << x_curv << " is not between keyPoints" << keyPts;
-}
-
-
-template <class DataTypes>
-void WireRestShape<DataTypes>::getInterpolationParam(const Real& x_curv, Real &_rho, Real &_A, Real &_Iy , Real &_Iz, Real &_Asy, Real &_Asz, Real &_J) const
-{
-    const Real x_used = x_curv - Real(EPSILON);
-    const type::vector<Real>& keyPts = d_keyPoints.getValue();
-
-    // Check in which section x_used belongs to and get access to this section material
-    for (sofa::Size i = 1; i < keyPts.size(); ++i)
-    {
-        if (x_used <= keyPts[i])
-        {
-            return l_sectionMaterials.get(i - 1)->getInterpolationParam(_rho, _A, _Iy, _Iz, _Asy, _Asz, _J);
-        }
-    }
-
-    msg_error() << " problem in getInterpolationParam : x_curv " << x_curv << " is not between keyPoints" << keyPts;
-}
-
-
-
-template <class DataTypes>
 const BeamSection& WireRestShape<DataTypes>::getBeamSectionAtX(const Real& x_curv) const
 {
     const Real x_used = x_curv - Real(EPSILON);
@@ -318,7 +279,26 @@ const BeamSection& WireRestShape<DataTypes>::getBeamSectionAtX(const Real& x_cur
 
 
 template <class DataTypes>
-void WireRestShape<DataTypes>::getMechanicalParamAtX(const Real& x_curv, Real& youngModulus, Real& cPoisson, Real& massDensity) const
+void WireRestShape<DataTypes>::getInterpolationParametersAtX(const Real& x_curv, Real &_A, Real &_Iy , Real &_Iz, Real &_Asy, Real &_Asz, Real &_J) const
+{
+    const Real x_used = x_curv - Real(EPSILON);
+    const type::vector<Real>& keyPts = d_keyPoints.getValue();
+
+    // Check in which section x_used belongs to and get access to this section material
+    for (sofa::Size i = 1; i < keyPts.size(); ++i)
+    {
+        if (x_used <= keyPts[i])
+        {
+            return l_sectionMaterials.get(i - 1)->getInterpolationParameters(_A, _Iy, _Iz, _Asy, _Asz, _J);
+        }
+    }
+
+    msg_error() << " problem in getInterpolationParam : x_curv " << x_curv << " is not between keyPoints" << keyPts;
+}
+
+
+template <class DataTypes>
+void WireRestShape<DataTypes>::getMechanicalParametersAtX(const Real& x_curv, Real& youngModulus, Real& cPoisson, Real& massDensity) const
 {
     const Real x_used = x_curv - Real(EPSILON);
     const type::vector<Real>& keyPts = d_keyPoints.getValue();
@@ -328,7 +308,7 @@ void WireRestShape<DataTypes>::getMechanicalParamAtX(const Real& x_curv, Real& y
     {
         if (x_used <= keyPts[i])
         {
-            return l_sectionMaterials.get(i - 1)->getMechanicalParamAtX(youngModulus, cPoisson, massDensity);
+            return l_sectionMaterials.get(i - 1)->getMechanicalParameters(youngModulus, cPoisson, massDensity);
         }
     }
 

--- a/src/BeamAdapter/component/engine/WireRestShape.inl
+++ b/src/BeamAdapter/component/engine/WireRestShape.inl
@@ -297,7 +297,7 @@ void WireRestShape<DataTypes>::getInterpolationParam(const Real& x_curv, Real &_
 
 
 template <class DataTypes>
-const BeamSection& WireRestShape<DataTypes>::getBeamSection(const Real& x_curv) const
+const BeamSection& WireRestShape<DataTypes>::getBeamSectionAtX(const Real& x_curv) const
 {
     const Real x_used = x_curv - Real(EPSILON);
     const type::vector<Real>& keyPts = d_keyPoints.getValue();
@@ -314,6 +314,25 @@ const BeamSection& WireRestShape<DataTypes>::getBeamSection(const Real& x_curv) 
     msg_error() << " problem in getBeamSection : x_curv " << x_curv << " is not between keyPoints" << keyPts;
     static const BeamSection emptySection{};
     return emptySection;
+}
+
+
+template <class DataTypes>
+void WireRestShape<DataTypes>::getMechanicalParamAtX(const Real& x_curv, Real& youngModulus, Real& cPoisson, Real& massDensity) const
+{
+    const Real x_used = x_curv - Real(EPSILON);
+    const type::vector<Real>& keyPts = d_keyPoints.getValue();
+
+    // Check in which section x_used belongs to and get access to this section material
+    for (auto i = 1; i < keyPts.size(); ++i)
+    {
+        if (x_used <= keyPts[i])
+        {
+            return l_sectionMaterials.get(i - 1)->getMechanicalParamAtX(youngModulus, cPoisson, massDensity);
+        }
+    }
+
+    msg_error() << " problem in getMechanicalParamAtX : x_curv " << x_curv << " is not between keyPoints" << keyPts;
 }
 
 

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
@@ -118,6 +118,8 @@ protected:
 
         Real _A, _L, _Iy, _Iz, _Asy, _Asz, _J; ///< Interpolation & geometrical parameters
         Real _rho;
+        Real _youngM;
+        Real _cPoisson;
     };
 
 public:
@@ -198,7 +200,6 @@ public:
 
 protected :
     SingleLink<AdaptiveBeamForceFieldAndMass<DataTypes>, BInterpolation, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_interpolation;
-    SingleLink<AdaptiveBeamForceFieldAndMass<DataTypes>, WireRestShape, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_instrumentParameters;
 
     void applyMassLarge( VecDeriv& df, int bIndex, Index nd0Id, Index nd1Id, SReal factor);
     void applyStiffnessLarge( VecDeriv& df, const VecDeriv& dx, int beam, Index nd0Id, Index nd1Id, SReal factor );

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
@@ -65,7 +65,6 @@ AdaptiveBeamForceFieldAndMass<DataTypes>::AdaptiveBeamForceFieldAndMass()
     , d_useShearStressComputation(initData(&d_useShearStressComputation, true, "shearStressComputation","if false, suppress the shear stress in the computation"))
     , d_reinforceLength(initData(&d_reinforceLength, false, "reinforceLength", "if true, a separate computation for the error in elongation is peformed"))
     , l_interpolation(initLink("interpolation","Path to the Interpolation component on scene"))
-    , l_instrumentParameters(initLink("instrumentParameters", "link to an object specifying physical parameters based on abscissa"))
 {
 }
 
@@ -105,37 +104,30 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::computeGravityVector()
 template<class DataTypes>
 void AdaptiveBeamForceFieldAndMass<DataTypes>::computeStiffness(int beamId, BeamLocalMatrices& beamLocalMatrices)
 {
-    Real x_curv = 0.0 ;
-    Real _nu = 0.0 ;
-    Real _E = 0.0 ;
-
-    ///Get the curvilinear abscissa of the extremity of the beam
-    l_interpolation->getYoungModulusAtX(beamId, x_curv, _E, _nu);
-
     /// material parameters
-    Real _G = _E / (2.0 * (1.0 + _nu));
+    Real _G = beamLocalMatrices._youngM / (2.0 * (1.0 + beamLocalMatrices._cPoisson));
 
     Real phiy, phiz;
     Real L2 = (Real) (beamLocalMatrices._L * beamLocalMatrices._L);
     Real L3 = (Real) (L2 * beamLocalMatrices._L);
-    Real EIy = (Real)(_E * beamLocalMatrices._Iy);
-    Real EIz = (Real)(_E * beamLocalMatrices._Iz);
+    Real EIy = (Real)(beamLocalMatrices._youngM * beamLocalMatrices._Iy);
+    Real EIz = (Real)(beamLocalMatrices._youngM * beamLocalMatrices._Iz);
 
     /// Find shear-deformation parameters
     if (beamLocalMatrices._Asy == 0)
         phiy = 0.0;
     else
-        phiy =(L2 ==0)? 0.0: (Real)(24.0*(1.0+_nu)* beamLocalMatrices._Iz/(beamLocalMatrices._Asy*L2));
+        phiy = (L2 == 0) ? 0.0 : (Real)(24.0 * (1.0 + beamLocalMatrices._cPoisson) * beamLocalMatrices._Iz / (beamLocalMatrices._Asy * L2));
 
     if (beamLocalMatrices._Asz == 0)
         phiz = 0.0;
     else
-        phiz =(L2 ==0)? 0.0: (Real)(24.0*(1.0+_nu)* beamLocalMatrices._Iy/(beamLocalMatrices._Asz*L2));
+        phiz = (L2 == 0) ? 0.0 : (Real)(24.0 * (1.0 + beamLocalMatrices._cPoisson) * beamLocalMatrices._Iy / (beamLocalMatrices._Asz * L2));
 
     beamLocalMatrices.m_K00.clear(); beamLocalMatrices.m_K01.clear(); beamLocalMatrices.m_K10.clear(); beamLocalMatrices.m_K11.clear();
 
     /// diagonal values
-    beamLocalMatrices.m_K00[0][0] = beamLocalMatrices.m_K11[0][0] = (beamLocalMatrices._L == 0.0)? 0.0 :_E* beamLocalMatrices._A/ beamLocalMatrices._L;
+    beamLocalMatrices.m_K00[0][0] = beamLocalMatrices.m_K11[0][0] = (beamLocalMatrices._L == 0.0)? 0.0 : beamLocalMatrices._youngM * beamLocalMatrices._A/ beamLocalMatrices._L;
     beamLocalMatrices.m_K00[1][1] = beamLocalMatrices.m_K11[1][1] = (L3 == 0.0)? 0.0 :(Real)(12.0*EIz/(L3*(1.0+phiy)));
     beamLocalMatrices.m_K00[2][2] = beamLocalMatrices.m_K11[2][2] = (L3 == 0.0)? 0.0 : (Real)(12.0*EIy/(L3*(1.0+phiz)));
     beamLocalMatrices.m_K00[3][3] = beamLocalMatrices.m_K11[3][3] = (beamLocalMatrices._L == 0.0)? 0.0 : _G* beamLocalMatrices._J/ beamLocalMatrices._L;
@@ -546,28 +538,12 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::addForce (const MechanicalParams*
         /// Update Interpolation & geometrical parameters with current positions
 
         /// material parameters
-        beamMatrices._rho = d_massDensity.getValue();
+        auto beamInterpolation = l_interpolation.get();
+        beamInterpolation->getInterpolationParameters(beamId, beamMatrices._L, beamMatrices._A, beamMatrices._Iy,
+            beamMatrices._Iz, beamMatrices._Asy, beamMatrices._Asz, beamMatrices._J);
 
-        
-        /// Temp : we only overide values for which a Data has been set in the WireRestShape
-        if (!l_instrumentParameters.empty())
-        {
-            Real x_curv = 0;
-            l_interpolation->getAbsCurvXFromBeam(beamId, x_curv);
-
-            /// The length of the beams is only known to the interpolation !
-            l_instrumentParameters.get()->getInterpolationParam(x_curv, beamMatrices._rho, beamMatrices._A, beamMatrices._Iy,
-                beamMatrices._Iz, beamMatrices._Asy, beamMatrices._Asz, beamMatrices._J);
-        }
-        else
-        {
-            l_interpolation->getInterpolationParam(beamId, beamMatrices._L, beamMatrices._A, beamMatrices._Iy,
-                beamMatrices._Iz, beamMatrices._Asy, beamMatrices._Asz, beamMatrices._J);
-
-            Real youngM, cPoisson;
-            l_interpolation->getMechanicalParam(beamId, youngM, cPoisson, beamMatrices._rho);
-        }
-
+        beamMatrices._rho = d_massDensity.getValue(); // for BeamInterpolation which is not overidding the _rho
+        beamInterpolation->getMechanicalParameters(beamId, beamMatrices._youngM, beamMatrices._cPoisson, beamMatrices._rho);
 
         /// compute the local mass matrices
         if(d_computeMass.getValue())

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
@@ -548,20 +548,24 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::addForce (const MechanicalParams*
         /// material parameters
         beamMatrices._rho = d_massDensity.getValue();
 
+        
         /// Temp : we only overide values for which a Data has been set in the WireRestShape
-        if (l_instrumentParameters.get())
+        if (!l_instrumentParameters.empty())
         {
             Real x_curv = 0;
             l_interpolation->getAbsCurvXFromBeam(beamId, x_curv);
 
             /// The length of the beams is only known to the interpolation !
-            l_instrumentParameters->getInterpolationParam(x_curv, beamMatrices._rho, beamMatrices._A, beamMatrices._Iy,
+            l_instrumentParameters.get()->getInterpolationParam(x_curv, beamMatrices._rho, beamMatrices._A, beamMatrices._Iy,
                 beamMatrices._Iz, beamMatrices._Asy, beamMatrices._Asz, beamMatrices._J);
         }
         else
         {
             l_interpolation->getInterpolationParam(beamId, beamMatrices._L, beamMatrices._A, beamMatrices._Iy,
                 beamMatrices._Iz, beamMatrices._Asy, beamMatrices._Asz, beamMatrices._J);
+
+            Real youngM, cPoisson;
+            l_interpolation->getMechanicalParam(beamId, youngM, cPoisson, beamMatrices._rho);
         }
 
 

--- a/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.h
+++ b/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.h
@@ -234,9 +234,7 @@ public:
     DataVecDeriv d_dataG;
 
 protected :
-
     SingleLink<AdaptiveInflatableBeamForceField<DataTypes>, BInterpolation          , BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_interpolation;
-    SingleLink<AdaptiveInflatableBeamForceField<DataTypes>, WireRestShape<DataTypes>, BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> l_instrumentParameters;
 
     void applyMassLarge( VecDeriv& df, const VecDeriv& dx, int bIndex, Index nd0Id, Index nd1Id, SReal factor);
     void applyStiffnessLarge( VecDeriv& df, const VecDeriv& dx, int beam, Index nd0Id, Index nd1Id, SReal factor );

--- a/src/BeamAdapter/component/model/BaseRodSectionMaterial.h
+++ b/src/BeamAdapter/component/model/BaseRodSectionMaterial.h
@@ -86,8 +86,11 @@ public:
     /// Returns the mass density and the BeamSection of this section
     void getInterpolationParam(Real& _rho, Real& _A, Real& _Iy, Real& _Iz, Real& _Asy, Real& _Asz, Real& _J) const;
 
-    /// Returns the BeamSection data structure of this section
-    const BeamSection& getBeamSection() const { return beamSection; };
+    /// Returns the Young modulus, Poisson's and massDensity coefficient of this section
+    void getMechanicalParamAtX(Real& youngModulus, Real& cPoisson, Real& massDensity) const;
+
+    /// Returns the BeamSection @sa m_beamSection corresponding to this section
+    [[nodiscard]] const BeamSection& getBeamSection() const  { return m_beamSection; }
 
     /// This function is called to get the rest position of the beam depending on the current curved abscisse given in parameter 
     virtual void getRestTransformOnX(Transform& global_H_local, const Real& x_used, const Real& x_start)
@@ -115,7 +118,7 @@ public:
 
 private:
     /// Internal structure to store physical parameter of the a beam section
-    BeamSection beamSection;
+    BeamSection m_beamSection;
 };
 
 #if !defined(SOFA_PLUGIN_BEAMADAPTER_BASERODSECTIONMATERIAL_CPP)

--- a/src/BeamAdapter/component/model/BaseRodSectionMaterial.h
+++ b/src/BeamAdapter/component/model/BaseRodSectionMaterial.h
@@ -80,17 +80,15 @@ public:
     /// Returns the total length of this section. To be set or computed by child.
     [[nodiscard]] Real getLength() const { return d_length.getValue(); }
 
-    /// Returns the Young modulus and Poisson's coefficient of this section
-    void getYoungModulusAtX(Real& youngModulus, Real& cPoisson) const;
-
-    /// Returns the mass density and the BeamSection of this section
-    void getInterpolationParam(Real& _rho, Real& _A, Real& _Iy, Real& _Iz, Real& _Asy, Real& _Asz, Real& _J) const;
-
-    /// Returns the Young modulus, Poisson's and massDensity coefficient of this section
-    void getMechanicalParamAtX(Real& youngModulus, Real& cPoisson, Real& massDensity) const;
 
     /// Returns the BeamSection @sa m_beamSection corresponding to this section
-    [[nodiscard]] const BeamSection& getBeamSection() const  { return m_beamSection; }
+    [[nodiscard]] const BeamSection& getBeamSection() const { return m_beamSection; }
+
+    /// Returns the mass density and the BeamSection of this section
+    void getInterpolationParameters(Real& _A, Real& _Iy, Real& _Iz, Real& _Asy, Real& _Asz, Real& _J) const;
+
+    /// Returns the Young modulus, Poisson's and massDensity coefficient of this section
+    void getMechanicalParameters(Real& youngModulus, Real& cPoisson, Real& massDensity) const;
 
     /// This function is called to get the rest position of the beam depending on the current curved abscisse given in parameter 
     virtual void getRestTransformOnX(Transform& global_H_local, const Real& x_used, const Real& x_start)

--- a/src/BeamAdapter/component/model/BaseRodSectionMaterial.inl
+++ b/src/BeamAdapter/component/model/BaseRodSectionMaterial.inl
@@ -49,14 +49,14 @@ void BaseRodSectionMaterial<DataTypes>::init()
     // Prepare beam sections
     double r = this->d_radius.getValue();
     double rInner = this->d_innerRadius.getValue();
-    this->beamSection._r = r;
-    this->beamSection._rInner = rInner;
-    this->beamSection._Iz = M_PI * (r * r * r * r - rInner * rInner * rInner * rInner) / 4.0;
-    this->beamSection._Iy = this->beamSection._Iz;
-    this->beamSection._J = this->beamSection._Iz + this->beamSection._Iy;
-    this->beamSection._A = M_PI * (r * r - rInner * rInner);
-    this->beamSection._Asy = 0.0;
-    this->beamSection._Asz = 0.0;
+    this->m_beamSection._r = r;
+    this->m_beamSection._rInner = rInner;
+    this->m_beamSection._Iz = M_PI * (r * r * r * r - rInner * rInner * rInner * rInner) / 4.0;
+    this->m_beamSection._Iy = this->m_beamSection._Iz;
+    this->m_beamSection._J = this->m_beamSection._Iz + this->m_beamSection._Iy;
+    this->m_beamSection._A = M_PI * (r * r - rInner * rInner);
+    this->m_beamSection._Asy = 0.0;
+    this->m_beamSection._Asz = 0.0;
 
     // call delegate method to init the section
     bool res = initSection();
@@ -79,15 +79,25 @@ void BaseRodSectionMaterial<DataTypes>::getYoungModulusAtX(Real& youngModulus, R
 template <class DataTypes>
 void BaseRodSectionMaterial<DataTypes>::getInterpolationParam(Real& _rho, Real& _A, Real& _Iy, Real& _Iz, Real& _Asy, Real& _Asz, Real& _J) const
 {
-    if (d_massDensity.isSet())
+    if (d_massDensity.isSet()) {
         _rho = d_massDensity.getValue();
+    }
 
-    _A = beamSection._A;
-    _Iy = beamSection._Iy;
-    _Iz = beamSection._Iz;
-    _Asy = beamSection._Asy;
-    _Asz = beamSection._Asz;
-    _J = beamSection._J;
+    _A = m_beamSection._A; 
+    _Iy = m_beamSection._Iy;
+    _Iz = m_beamSection._Iz;
+    _Asy = m_beamSection._Asy;
+    _Asz = m_beamSection._Asz;
+    _J = m_beamSection._J;
+}
+
+
+template <class DataTypes>
+void BaseRodSectionMaterial<DataTypes>::getMechanicalParamAtX(Real& youngModulus, Real& cPoisson, Real& massDensity) const
+{
+    youngModulus = this->d_youngModulus.getValue();
+    cPoisson = this->d_poissonRatio.getValue();
+    massDensity = this->d_massDensity.getValue();
 }
 
 } // namespace sofa::beamadapter

--- a/src/BeamAdapter/component/model/BaseRodSectionMaterial.inl
+++ b/src/BeamAdapter/component/model/BaseRodSectionMaterial.inl
@@ -69,20 +69,8 @@ void BaseRodSectionMaterial<DataTypes>::init()
 
 
 template <class DataTypes>
-void BaseRodSectionMaterial<DataTypes>::getYoungModulusAtX(Real& youngModulus, Real& cPoisson) const
+void BaseRodSectionMaterial<DataTypes>::getInterpolationParameters(Real& _A, Real& _Iy, Real& _Iz, Real& _Asy, Real& _Asz, Real& _J) const
 {
-    youngModulus = this->d_youngModulus.getValue();
-    cPoisson = this->d_poissonRatio.getValue();
-}
-
-
-template <class DataTypes>
-void BaseRodSectionMaterial<DataTypes>::getInterpolationParam(Real& _rho, Real& _A, Real& _Iy, Real& _Iz, Real& _Asy, Real& _Asz, Real& _J) const
-{
-    if (d_massDensity.isSet()) {
-        _rho = d_massDensity.getValue();
-    }
-
     _A = m_beamSection._A; 
     _Iy = m_beamSection._Iy;
     _Iz = m_beamSection._Iz;
@@ -93,7 +81,7 @@ void BaseRodSectionMaterial<DataTypes>::getInterpolationParam(Real& _rho, Real& 
 
 
 template <class DataTypes>
-void BaseRodSectionMaterial<DataTypes>::getMechanicalParamAtX(Real& youngModulus, Real& cPoisson, Real& massDensity) const
+void BaseRodSectionMaterial<DataTypes>::getMechanicalParameters(Real& youngModulus, Real& cPoisson, Real& massDensity) const
 {
     youngModulus = this->d_youngModulus.getValue();
     cPoisson = this->d_poissonRatio.getValue();


### PR DESCRIPTION
Add getter for:
- `getBeamSection `
- `getInterpolationParameters`
- `getMechanicalParameters`

Depending on the modeling: 
- If `BeamInterpolation` is used. The method are overidden from `BaseBeamInterpolation` to use internal Data from `BeamInterpolation`.
- If `WireBeamInterpolation` is used: The overidden methods return the values from the `WireRestShape` which redirect to the corresponding method inside the `BaseRodSection` (depending on the current curvilinar abscissa)

**Breaking:**
- Remove the method `GetYoungModulus` by `getMechanicalParameters` as Poisson Ratio and Density of mass is also return at the same time.
- Rename several methods from xxxxParam to xxxxParameters and to xxxxParametersAtX (when depending on the curvilinear abscissa)
- Remove pointer to the `WireRestShape` in the FEM, now only use the pointer to the `BaseInterpolation` component which hide the use of the `WireRestShape` if it is as `WireBeamInterpolation`.

Todo: remove the MassDensity Data from the FEM. It should be defined either in RodSection or in BeamInterpolation.