### PR TITLE
Apply new factory registration mechanism + refresh

### DIFF
--- a/BeamAdapter_test/component/controller/AdaptiveBeamController_test.cpp
+++ b/BeamAdapter_test/component/controller/AdaptiveBeamController_test.cpp
@@ -1,4 +1,4 @@
-﻿/******************************************************************************
+/******************************************************************************
 *                              BeamAdapter plugin                             *
 *                  (c) 2006 Inria, University of Lille, CNRS                  *
 *                                                                             *
@@ -26,6 +26,8 @@
 
 TEST(AdaptiveBeamController, target)
 {
+    sofa::simpleapi::importPlugin("BeamAdapter");
+    
     const auto node = sofa::simpleapi::createNode("node");
     const auto controller = sofa::simpleapi::createObject(node, "AdaptiveBeamController");
 

--- a/src/BeamAdapter/component/BeamInterpolation.cpp
+++ b/src/BeamAdapter/component/BeamInterpolation.cpp
@@ -44,25 +44,17 @@
 namespace sofa::component::fem::_beaminterpolation_
 {
 
-using namespace sofa::defaulttype;
-
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-//TODO(damien): Il faut remplacer les descriptions dans RegisterObject par un vrai description
-static int BeamInterpolationClass = core::RegisterObject("Adaptive Beam Interpolation")
-.add< BeamInterpolation<Rigid3Types> >(true)
-;
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// Explicit template instanciation of extern template.
-////////////////////////////////////////////////////////////////////////////////////////////////////
-template class SOFA_BEAMADAPTER_API BeamInterpolation<Rigid3Types>;
+template class SOFA_BEAMADAPTER_API BeamInterpolation<sofa::defaulttype::Rigid3Types>;
 
 } // namespace sofa::component::fem::_beaminterpolation_
+
+namespace beamadapter
+{
+
+void registerBeamInterpolation(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Adaptive Beam Interpolation")
+                             .add< sofa::component::fem::_beaminterpolation_::BeamInterpolation<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/WireBeamInterpolation.cpp
+++ b/src/BeamAdapter/component/WireBeamInterpolation.cpp
@@ -41,22 +41,18 @@
 
 namespace sofa::component::fem::_wirebeaminterpolation_
 {
-using namespace sofa::defaulttype;
 
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-//TODO(damien): Il faut remplacer les descriptions dans RegisterObject par un vrai description
-static int WireBeamInterpolationClass = core::RegisterObject("Adaptive Beam Interpolation on Wire rest Shape")
-.add< WireBeamInterpolation<Rigid3Types> >();
-
-template class SOFA_BEAMADAPTER_API WireBeamInterpolation<Rigid3Types>;
+template class SOFA_BEAMADAPTER_API WireBeamInterpolation<sofa::defaulttype::Rigid3Types>;
 
 } // namespace sofa::component::fem::_wirebeaminterpolation_
 
+namespace beamadapter
+{
 
+void registerWireBeamInterpolation(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Adaptive Beam Interpolation on Wire rest Shape")
+                             .add< sofa::component::fem::_wirebeaminterpolation_::WireBeamInterpolation<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.cpp
+++ b/src/BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.cpp
@@ -56,25 +56,17 @@ void AdaptiveBeamLengthConstraintResolution::store(int line, SReal* force, bool 
         *m_active = (force[line] != 0);
 }
 
-
-using namespace sofa::defaulttype;
-using namespace sofa::helper;
-using core::RegisterObject;
-
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-static int AdaptiveBeamLengthConstraintClass = RegisterObject("Constrain the length of a beam.")
-                .add< AdaptiveBeamLengthConstraint<Rigid3Types> >(true) // default template
-
-        ;
-
-template class AdaptiveBeamLengthConstraint<Rigid3Types>;
-
+template class AdaptiveBeamLengthConstraint<sofa::defaulttype::Rigid3Types>;
 
 } // namespace sofa::component::constraintset::_adaptivebeamlengthconstraint_
 
+namespace beamadapter
+{
+
+void registerAdaptiveBeamLengthConstraint(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Constrain the length of a beam.")
+                             .add< sofa::component::constraintset::_adaptivebeamlengthconstraint_::AdaptiveBeamLengthConstraint<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.cpp
+++ b/src/BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.cpp
@@ -37,7 +37,6 @@ using sofa::core::objectmodel::BaseObjectDescription ;
 using sofa::component::DeprecatedComponent;
 using sofa::defaulttype::Rigid3Types;
 using sofa::defaulttype::Rigid3Types;
-using sofa::core::RegisterObject;
 
 
 namespace sofa::component::constraintset::_adaptiveBeamSlidingConstraint_
@@ -78,25 +77,20 @@ void AdaptiveBeamSlidingConstraintResolution::store(int line, double* force, boo
         *m_slidingDisp = force[line+2] * m_slidingW;
 }
 
-
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-SOFA_DECL_CLASS(AdaptiveBeamSlidingConstraint)
-
-int AdaptiveBeamSlidingConstraintClass = RegisterObject("Constrain a rigid to be attached to a beam (only in position, not the orientation)")
-                .add< AdaptiveBeamSlidingConstraint<Rigid3Types> >()
-        
-        ;
-
 template class SOFA_BEAMADAPTER_API AdaptiveBeamSlidingConstraint<Rigid3Types>;
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 } // namespace sofa::component::constraintset::_adaptiveBeamSlidingConstraint_
+
+namespace beamadapter
+{
+
+void registerAdaptiveBeamSlidingConstraint(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Constrain a rigid to be attached to a beam (only in position, not the orientation).")
+                             .add< sofa::component::constraintset::_adaptiveBeamSlidingConstraint_::AdaptiveBeamSlidingConstraint<Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/controller/AdaptiveBeamController.cpp
+++ b/src/BeamAdapter/component/controller/AdaptiveBeamController.cpp
@@ -44,25 +44,19 @@
 namespace sofa::component::controller::_adaptivebeamcontroller_
 {
 
-using sofa::defaulttype::Rigid3Types;
-using core::RegisterObject;
-
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-//TODO(dmarchal 2017-06-01): Il faut remplacer les descriptions dans RegisterObject par un vrai description
-int AdaptiveBeamControllerClass = RegisterObject("Adaptive beam controller")
-.add< AdaptiveBeamController<Rigid3Types> >()
-;
-
-template class SOFA_BEAMADAPTER_API AdaptiveBeamController<Rigid3Types>;
-
+template class SOFA_BEAMADAPTER_API AdaptiveBeamController<sofa::defaulttype::Rigid3Types>;
 
 } // namespace sofa::component::controller::_adaptivebeamcontroller_
+
+namespace beamadapter
+{
+
+void registerAdaptiveBeamController(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Adaptive beam controller.")
+                             .add< sofa::component::controller::_adaptivebeamcontroller_::AdaptiveBeamController<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter
 
 

--- a/src/BeamAdapter/component/controller/BeamAdapterActionController.cpp
+++ b/src/BeamAdapter/component/controller/BeamAdapterActionController.cpp
@@ -31,10 +31,17 @@
 namespace sofa::component::controller
 {
 
-const static int BeamAdapterActionControllerClass = core::RegisterObject("BeamAdapterActionController")
-    .add< BeamAdapterActionController<sofa::defaulttype::Rigid3Types> >()
-    ;
-
 template class SOFA_BEAMADAPTER_API BeamAdapterActionController<sofa::defaulttype::Rigid3Types>;
 
-} // namespace sofa::component::controller
+} // namespace
+
+namespace beamadapter
+{
+
+void registerBeamAdapterActionController(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("BeamAdapterActionController")
+                                            .add< sofa::component::controller::BeamAdapterActionController<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.cpp
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.cpp
@@ -43,23 +43,17 @@
 namespace sofa::component::controller::_interventionalradiologycontroller_
 {
 
-using namespace sofa::defaulttype;
-
-
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-static int InterventionalRadiologyControllerClass = core::RegisterObject("Provides a Mouse & Keyboard user control on an EdgeSet Topology.")
-.add< InterventionalRadiologyController<Rigid3Types> >(true)
-;
-
-template class SOFA_BEAMADAPTER_API InterventionalRadiologyController<Rigid3Types>;
+template class SOFA_BEAMADAPTER_API InterventionalRadiologyController<sofa::defaulttype::Rigid3Types>;
 
 } // namespace sofa::component::controller::_interventionalradiologycontroller_
 
+namespace beamadapter
+{
 
+void registerInterventionalRadiologyController(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Provides a Mouse & Keyboard user control on an EdgeSet Topology.")
+                             .add< sofa::component::controller::_interventionalradiologycontroller_::InterventionalRadiologyController<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/controller/SutureController.cpp
+++ b/src/BeamAdapter/component/controller/SutureController.cpp
@@ -42,21 +42,17 @@
 namespace sofa::component::controller::_suturecontroller_
 {
 
-using namespace sofa::defaulttype;
+template class SOFA_BEAMADAPTER_API SutureController<sofa::defaulttype::Rigid3Types>;
 
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
+} // namespace
 
-static int SutureControllerClass = core::RegisterObject("Provides a Mouse & Keyboard user control on an EdgeSet Topology.")
-.add< SutureController<Rigid3Types> >(true)
+namespace beamadapter
+{
 
-;
+void registerSutureController(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Provides a Mouse & Keyboard user control on an EdgeSet Topology.")
+                             .add< sofa::component::controller::_suturecontroller_::SutureController<sofa::defaulttype::Rigid3Types> >());
+}
 
-template class SOFA_BEAMADAPTER_API SutureController<Rigid3Types>;
-
-} // namespace sofa::component::controller::_suturecontroller_
+} // namespace beamadapter

--- a/src/BeamAdapter/component/engine/SteerableCatheter.cpp
+++ b/src/BeamAdapter/component/engine/SteerableCatheter.cpp
@@ -41,22 +41,17 @@
 namespace sofa::component::engine
 {
 
-using namespace sofa::defaulttype;
-
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-//TODO(damien): Il faut remplacer les descriptions dans RegisterObject par un vrai description
-static int SteerableCatheterClass = core::RegisterObject("")
-.add< SteerableCatheter<Rigid3Types> >()
-
-;
-
-template class SOFA_BEAMADAPTER_API SteerableCatheter<Rigid3Types>;
+template class SOFA_BEAMADAPTER_API SteerableCatheter<sofa::defaulttype::Rigid3Types>;
 
 }// namespace sofa::component::engine
+
+namespace beamadapter
+{
+
+void registerSteerableCatheter(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("")
+                             .add< sofa::component::engine::SteerableCatheter<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/engine/SteerableCatheter.cpp
+++ b/src/BeamAdapter/component/engine/SteerableCatheter.cpp
@@ -50,7 +50,7 @@ namespace beamadapter
 
 void registerSteerableCatheter(sofa::core::ObjectFactory* factory)
 {
-    factory->registerObjects(sofa::core::ObjectRegistrationData("")
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Catheter object with a flexible tip based on WireRestShape")
                              .add< sofa::component::engine::SteerableCatheter<sofa::defaulttype::Rigid3Types> >());
 }
 

--- a/src/BeamAdapter/component/engine/WireRestShape.cpp
+++ b/src/BeamAdapter/component/engine/WireRestShape.cpp
@@ -40,24 +40,18 @@
 
 namespace sofa::component::engine::_wirerestshape_
 {
-using namespace sofa::defaulttype;
 
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-const int WireRestShapeClass = core::RegisterObject("Describe the shape functions on multiple segments using curvilinear abscissa")
-.add< WireRestShape<Rigid3Types> >(true)
-
-;
-
-template class SOFA_BEAMADAPTER_API WireRestShape<Rigid3Types>;
-
+template class SOFA_BEAMADAPTER_API WireRestShape<sofa::defaulttype::Rigid3Types>;
 
 } // namespace sofa::component::engine::_wirerestshape_
 
+namespace beamadapter
+{
 
+void registerWireRestShape(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Describe the shape functions on multiple segments using curvilinear abscissa")
+                             .add< sofa::component::engine::_wirerestshape_::WireRestShape<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.cpp
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.cpp
@@ -32,7 +32,6 @@
 //
 #define SOFA_PLUGIN_BEAMADAPTER_ADAPTIVEBEAMFORCEFIELD_CPP
 
-//////////////////////// Inclusion of headers...from wider to narrower/closer //////////////////////
 #include <sofa/defaulttype/RigidTypes.h>
 #include <BeamAdapter/config.h>
 #include <sofa/core/ObjectFactory.h>
@@ -43,21 +42,17 @@
 namespace sofa::component::forcefield::_adaptivebeamforcefieldandmass_
 {
 
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-//TODO(damien): Il faut remplacer les descriptions dans RegisterObject par un vrai description
-const static int AdaptiveBeamForceFieldAndMassClass = sofa::core::RegisterObject("Adaptive Beam finite elements")
-.add< AdaptiveBeamForceFieldAndMass<sofa::defaulttype::Rigid3Types> >()
-;
-
 template class SOFA_BEAMADAPTER_API AdaptiveBeamForceFieldAndMass<sofa::defaulttype::Rigid3Types>;
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+} // namespace
 
-} // namespace sofa::component::forcefield::_adaptivebeamforcefieldandmass_
+namespace beamadapter
+{
+
+void registerAdaptiveBeamForceFieldAndMass(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Adaptive Beam finite elements")
+                             .add< sofa::component::forcefield::_adaptivebeamforcefieldandmass_::AdaptiveBeamForceFieldAndMass<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.cpp
+++ b/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.cpp
@@ -42,25 +42,17 @@
 namespace sofa::component::forcefield::_AdaptiveInflatableBeamForceField_
 {
 
-using sofa::core::RegisterObject ;
-using sofa::defaulttype::Rigid3fTypes;
-using sofa::defaulttype::Rigid3dTypes;
-
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-//TODO(damien): Il faut remplacer les descriptions dans RegisterObject par un vrai description
-static int AdaptiveInflatableBeamForceFieldClass = RegisterObject("Adaptive Beam finite elements")
-.add< AdaptiveInflatableBeamForceField<Rigid3Types> >()
-;
-
-template class SOFA_BEAMADAPTER_API AdaptiveInflatableBeamForceField<Rigid3Types>;
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
+template class SOFA_BEAMADAPTER_API AdaptiveInflatableBeamForceField<sofa::defaulttype::Rigid3Types>;
 
 } // namespace sofa::component::forcefield::_AdaptiveInflatableBeamForceField_
+
+namespace beamadapter
+{
+
+void registerAdaptiveInflatableBeamForceField(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Adaptive Beam finite elements")
+                             .add< sofa::component::forcefield::_AdaptiveInflatableBeamForceField_::AdaptiveInflatableBeamForceField<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.cpp
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.cpp
@@ -39,10 +39,11 @@
 
 #include <BeamAdapter/component/mapping/AdaptiveBeamMapping.inl>
 
+using namespace sofa::defaulttype;
+
 namespace sofa::component::mapping::_adaptivebeammapping_
 {
 
-using namespace defaulttype;
 using namespace core;
 using namespace core::behavior;
 
@@ -196,21 +197,19 @@ SOFA_BEAMADAPTER_API void AdaptiveBeamMapping<Rigid3Types, Rigid3Types >::comput
     dmsg_info()<<" ********** TEST J-Jt(transposed): ********** \n"<<Test;
 }
 
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// Register in the Factory
-static int AdaptiveBeamMappingClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
-.add< AdaptiveBeamMapping<Rigid3Types, Vec3Types   > >(true) //default template
-.add< AdaptiveBeamMapping<Rigid3Types, Rigid3Types > >()
-;
-
 template class SOFA_BEAMADAPTER_API AdaptiveBeamMapping<Rigid3Types, Vec3Types>;
 template class SOFA_BEAMADAPTER_API AdaptiveBeamMapping<Rigid3Types, Rigid3Types>;
 
 } // namespace sofa::component::mapping::_adaptivebeammapping_
+
+namespace beamadapter
+{
+
+void registerAdaptiveBeamMapping(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs.")
+                             .add< sofa::component::mapping::_adaptivebeammapping_::AdaptiveBeamMapping<Rigid3Types, Vec3Types   > >(true) //default template
+                             .add< sofa::component::mapping::_adaptivebeammapping_::AdaptiveBeamMapping<Rigid3Types, Rigid3Types > >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/BeamLengthMapping.cpp
+++ b/src/BeamAdapter/component/mapping/BeamLengthMapping.cpp
@@ -43,34 +43,20 @@
 namespace sofa::component::mapping
 {
 
-//using namespace defaulttype;
-using namespace core;
-using namespace core::behavior;
-using namespace sofa::defaulttype;
-
-
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-//SOFA_DECL_CLASS(BeamLengthMapping)
-
-// Register in the Factory
-int BeamLengthMappingClass = core::RegisterObject("computes the lengths of the beams")
-        .add< BeamLengthMapping<Rigid3Types, Vec1dTypes   > >(true) //default template
-        //.add< BeamLengthMapping<Rigid3Types, Rigid3Types > >()
-;
-
 namespace _beamlengthmapping_
 {
-    template class SOFA_BEAMADAPTER_API BeamLengthMapping<Rigid3dTypes, Vec1dTypes   >;
+    template class SOFA_BEAMADAPTER_API BeamLengthMapping<sofa::defaulttype::Rigid3dTypes, sofa::defaulttype::Vec1dTypes>;
 }
 
 } // namespace sofa::component::mapping
 
+namespace beamadapter
+{
 
+void registerBeamLengthMapping(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Compute the lengths of the beams.")
+                             .add< sofa::component::mapping::BeamLengthMapping<sofa::defaulttype::Rigid3Types, sofa::defaulttype::Vec1dTypes> >());
+}
 
-
+} // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/BeamProjectionDifferenceMultiMapping.cpp
+++ b/src/BeamAdapter/component/mapping/BeamProjectionDifferenceMultiMapping.cpp
@@ -34,10 +34,12 @@
 namespace beamadapter::mapping
 {
 
-using namespace sofa::defaulttype;
+void registerBeamProjectionDifferenceMultiMapping(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Computes the difference between given points and their projection on a beam.")
+                             .add< BeamProjectionDifferenceMultiMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types > >());
+}
 
-// Register in the Factory
-int BeamProjectionDifferenceMultiMappingClass = sofa::core::RegisterObject("Computes the difference between given points and their projection on a beam.")
-        .add< BeamProjectionDifferenceMultiMapping< Rigid3Types, Rigid3Types, Rigid3Types > >();
+template class SOFA_BEAMADAPTER_API BeamProjectionDifferenceMultiMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types >;
 
-} // namespace
+} // namespace beamadapter::mapping

--- a/src/BeamAdapter/component/mapping/BeamProjectionDifferenceMultiMapping.h
+++ b/src/BeamAdapter/component/mapping/BeamProjectionDifferenceMultiMapping.h
@@ -199,7 +199,6 @@ private:
 // Declares template as extern to avoid the code generation of the template for
 // each compilation unit. see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
 #if !defined(BEAMADAPTER_MAPPING_BEAMPROJECTIONDIFFERENCEMULTIMAPPING_CPP)
-//extern template class BeamProjectionDifferenceMultiMapping< sofa::defaulttype::Vec3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Vec3Types >;
 extern template class SOFA_BEAMADAPTER_API BeamProjectionDifferenceMultiMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types >;
 #endif
 

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.cpp
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.cpp
@@ -38,24 +38,17 @@
 namespace sofa::component::mapping
 {
 
-using namespace defaulttype;
-using namespace core;
-using namespace core::behavior;
-
-/////////////////////////////////////////// FACTORY ////////////////////////////////////////////////
-///
-/// Register the component into the sofa factory.
-/// For more details:
-/// https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/the-objectfactory/
-///
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// Register in the Factory
-static int MultiAdaptiveBeamMappingClass = core::RegisterObject("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs")
-.add< MultiAdaptiveBeamMapping< Rigid3Types, Vec3Types > >()
-
-;
-
-template class SOFA_BEAMADAPTER_API MultiAdaptiveBeamMapping< Rigid3Types, Vec3Types >;
+template class SOFA_BEAMADAPTER_API MultiAdaptiveBeamMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Vec3Types >;
 
 } // namespace sofa::component::mapping
+
+namespace beamadapter
+{
+
+void registerMultiAdaptiveBeamMapping(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs.")
+                             .add< sofa::component::mapping::MultiAdaptiveBeamMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Vec3Types > >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodMeshSection.cpp
+++ b/src/BeamAdapter/component/model/RodMeshSection.cpp
@@ -29,11 +29,17 @@
 namespace sofa::beamadapter
 {
 
-using namespace sofa::defaulttype;
-
-const int RodMeshSectionClass = core::RegisterObject("Class defining a Rod Section using a MeshLoader and material parameters.")
-    .add< RodMeshSection<Rigid3Types> >(true);
-
-template class SOFA_BEAMADAPTER_API RodMeshSection<Rigid3Types>;
+template class SOFA_BEAMADAPTER_API RodMeshSection<sofa::defaulttype::Rigid3Types>;
 
 }// namespace sofa::beamadapter
+
+namespace beamadapter
+{
+
+void registerRodMeshSection(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Class defining a Rod Section using a MeshLoader and material parameters.")
+                             .add< sofa::beamadapter::RodMeshSection<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodSpireSection.cpp
+++ b/src/BeamAdapter/component/model/RodSpireSection.cpp
@@ -30,11 +30,17 @@
 namespace sofa::beamadapter
 {
 
-using namespace sofa::defaulttype;
-
-const int RodSpireSectionClass = core::RegisterObject("Class defining a rod spire section, defining material and geometry parameters.")
-    .add< RodSpireSection<Rigid3Types> >(true);
-
-template class SOFA_BEAMADAPTER_API RodSpireSection<Rigid3Types>;
+template class SOFA_BEAMADAPTER_API RodSpireSection<sofa::defaulttype::Rigid3Types>;
 
 }// namespace sofa::beamadapter
+
+namespace beamadapter
+{
+
+void registerRodSpireSection(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Class defining a rod spire section, defining material and geometry parameters.")
+                             .add< sofa::beamadapter::RodSpireSection<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodStraightSection.cpp
+++ b/src/BeamAdapter/component/model/RodStraightSection.cpp
@@ -31,11 +31,17 @@
 namespace sofa::beamadapter
 {
 
-using namespace sofa::defaulttype;
-
-const int RodStraightSectionClass = core::RegisterObject("Class defining a rod straight section Material, defining material and geometry parameters.")
-    .add< RodStraightSection<Rigid3Types> >(true);
-
-template class SOFA_BEAMADAPTER_API RodStraightSection<Rigid3Types>;
+template class SOFA_BEAMADAPTER_API RodStraightSection<sofa::defaulttype::Rigid3Types>;
 
 }// namespace sofa::beamadapter
+
+namespace beamadapter
+{
+
+void registerRodStraightSection(sofa::core::ObjectFactory* factory)
+{
+    factory->registerObjects(sofa::core::ObjectRegistrationData("Class defining a rod straight section Material, defining material and geometry parameters.")
+                             .add< sofa::beamadapter::RodStraightSection<sofa::defaulttype::Rigid3Types> >());
+}
+
+} // namespace beamadapter

--- a/src/BeamAdapter/config.h.in
+++ b/src/BeamAdapter/config.h.in
@@ -32,3 +32,9 @@
 #else
 #  define SOFA_BEAMADAPTER_API SOFA_IMPORT_DYNAMIC_LIBRARY
 #endif
+
+namespace beamadapter
+{
+    constexpr const char* MODULE_NAME = "@PROJECT_NAME@";
+    constexpr const char* MODULE_VERSION = "@PROJECT_VERSION@";
+} // namespace beamadapter

--- a/src/BeamAdapter/initBeamAdapter.cpp
+++ b/src/BeamAdapter/initBeamAdapter.cpp
@@ -22,65 +22,113 @@
 #include <BeamAdapter/initBeamAdapter.h>
 
 #include <sofa/core/ObjectFactory.h>
-using sofa::core::ObjectFactory;
+#include <sofa/helper/system/PluginManager.h>
 
-#ifdef SOFA_DEV
-#include <BeamAdapter/component/AdaptiveBeamContactMapper.h>
-#include <BeamAdapter/component/MultiAdaptiveBeamContactMapper.h>
-#endif // SOFA_DEV
+namespace beamadapter
+{
+
+extern void registerBeamInterpolation(sofa::core::ObjectFactory* factory);
+extern void registerWireBeamInterpolation(sofa::core::ObjectFactory* factory);
+extern void registerAdaptiveBeamLengthConstraint(sofa::core::ObjectFactory* factory);
+extern void registerAdaptiveBeamSlidingConstraint(sofa::core::ObjectFactory* factory);
+extern void registerAdaptiveBeamController(sofa::core::ObjectFactory* factory);
+extern void registerBeamAdapterActionController(sofa::core::ObjectFactory* factory);
+extern void registerInterventionalRadiologyController(sofa::core::ObjectFactory* factory);
+extern void registerSutureController(sofa::core::ObjectFactory* factory);
+extern void registerSteerableCatheter(sofa::core::ObjectFactory* factory);
+extern void registerWireRestShape(sofa::core::ObjectFactory* factory);
+extern void registerAdaptiveBeamForceFieldAndMass(sofa::core::ObjectFactory* factory);
+extern void registerAdaptiveInflatableBeamForceField(sofa::core::ObjectFactory* factory);
+extern void registerAdaptiveBeamMapping(sofa::core::ObjectFactory* factory);
+extern void registerBeamLengthMapping(sofa::core::ObjectFactory* factory);
+extern void registerMultiAdaptiveBeamMapping(sofa::core::ObjectFactory* factory);
+extern void registerRodMeshSection(sofa::core::ObjectFactory* factory);
+extern void registerRodSpireSection(sofa::core::ObjectFactory* factory);
+extern void registerRodStraightSection(sofa::core::ObjectFactory* factory);
+
+namespace mapping
+{
+
+extern void registerBeamProjectionDifferenceMultiMapping(sofa::core::ObjectFactory* factory);
+
+} // namespace mapping
+
+} // namespace beamadapter
 
 namespace sofa::component
 {
-	extern "C" {
-		SOFA_BEAMADAPTER_API void initExternalModule();
-		SOFA_BEAMADAPTER_API const char* getModuleLicense();
-		SOFA_BEAMADAPTER_API const char* getModuleName();
-		SOFA_BEAMADAPTER_API const char* getModuleVersion();
-		SOFA_BEAMADAPTER_API const char* getModuleDescription();
-		SOFA_BEAMADAPTER_API const char* getModuleComponentList();
-	}
 
-	void initBeamAdapter()
-	{
-		static bool first = true;
-		if (first)
-		{
-			first = false;
-		}
-	}
+using namespace beamadapter;
 
-	//Here are just several convenient functions to help user to know what contains the plugin
-	
-	void initExternalModule()
-	{
-		initBeamAdapter();
-	}
+extern "C" {
+    SOFA_BEAMADAPTER_API void initExternalModule();
+    SOFA_BEAMADAPTER_API const char* getModuleLicense();
+    SOFA_BEAMADAPTER_API const char* getModuleName();
+    SOFA_BEAMADAPTER_API const char* getModuleVersion();
+    SOFA_BEAMADAPTER_API const char* getModuleDescription();
+    SOFA_BEAMADAPTER_API void registerObjects(sofa::core::ObjectFactory* factory);
+}
 
-	const char* getModuleLicense()
-	{
-		return "INRIA and Digital-Trainers";
-	}
+void initBeamAdapter()
+{
+    static bool first = true;
+    if (first)
+    {
+        // make sure that this plugin is registered into the PluginManager
+        sofa::helper::system::PluginManager::getInstance().registerPlugin(MODULE_NAME);
+        
+        first = false;
+    }
+}
 
-	const char* getModuleName()
-	{
-		return sofa_tostring(SOFA_TARGET);
-	}
+//Here are just several convenient functions to help user to know what contains the plugin
 
-	const char* getModuleVersion()
-	{
-		return sofa_tostring(BEAMADAPTER_VERSION);
-	}
+void initExternalModule()
+{
+    initBeamAdapter();
+}
 
-	const char* getModuleDescription()
-	{
-		return "A dynamic adapter that modulates the DOF repartition of a beam model according to its radius of curvature.";
-	}
+const char* getModuleLicense()
+{
+    return "INRIA and Digital-Trainers";
+}
 
-	const char* getModuleComponentList()
-	{
-		/// string containing the names of the classes provided by the plugin
-		static std::string classes = ObjectFactory::getInstance()->listClassesFromTarget(sofa_tostring(SOFA_TARGET));
-		return classes.c_str();
-	}
+const char* getModuleName()
+{
+    return MODULE_NAME;
+}
+
+const char* getModuleVersion()
+{
+    return MODULE_VERSION;
+}
+
+const char* getModuleDescription()
+{
+    return "A dynamic adapter that modulates the DOF repartition of a beam model according to its radius of curvature.";
+}
+
+void registerObjects(sofa::core::ObjectFactory* factory)
+{
+    registerBeamInterpolation(factory);
+    registerWireBeamInterpolation(factory);
+    registerAdaptiveBeamLengthConstraint(factory);
+    registerAdaptiveBeamSlidingConstraint(factory);
+    registerAdaptiveBeamController(factory);
+    registerBeamAdapterActionController(factory);
+    registerInterventionalRadiologyController(factory);
+    registerSutureController(factory);
+    registerSteerableCatheter(factory);
+    registerWireRestShape(factory);
+    registerAdaptiveBeamForceFieldAndMass(factory);
+    registerAdaptiveInflatableBeamForceField(factory);
+    registerAdaptiveBeamMapping(factory);
+    registerBeamLengthMapping(factory);
+    registerMultiAdaptiveBeamMapping(factory);
+    registerRodMeshSection(factory);
+    registerRodSpireSection(factory);
+    registerRodStraightSection(factory);
+    mapping::registerBeamProjectionDifferenceMultiMapping(factory);
+}
 
 } // namespace sofa::component


### PR DESCRIPTION
See
- [SOFA #4429](https://github.com/sofa-framework/sofa/pull/4429)

\+ :
- introducing the beamadapter namespace
- cleaning
- config.in/init conformance

A future PR should uniform/clean/make consistent the namespaces, it is a real mess