### PR TITLE
[Tentative] Uniformize namespace

### DIFF
--- a/BeamAdapter_test/component/constraint/AdaptiveBeamSlidingConstraintTest.cpp
+++ b/BeamAdapter_test/component/constraint/AdaptiveBeamSlidingConstraintTest.cpp
@@ -45,11 +45,10 @@ using sofa::component::statecontainer::MechanicalObject ;
 
 #include <BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.h>
 #include <BeamAdapter/component/WireBeamInterpolation.h>
-using sofa::component::constraintset::AdaptiveBeamSlidingConstraint ;
-using sofa::component::fem::WireBeamInterpolation ;
 
+using namespace beamadapter;
 
-namespace sofa
+namespace beamadapter_test
 {
 
 template <typename DataTypes>

--- a/BeamAdapter_test/component/controller/InterventionalRadiologyController_test.cpp
+++ b/BeamAdapter_test/component/controller/InterventionalRadiologyController_test.cpp
@@ -35,7 +35,7 @@ using namespace sofa::testing;
 using namespace sofa::defaulttype;
 using namespace sofa::type;
 using namespace sofa::core::objectmodel;
-using namespace sofa::component::controller::_interventionalradiologycontroller_;
+using namespace beamadapter;
 
 class InterventionalRadiologyController_test : public BaseTest
 {

--- a/BeamAdapter_test/component/forcefield/AdaptiveBeamForceFieldAndMassTest.cpp
+++ b/BeamAdapter_test/component/forcefield/AdaptiveBeamForceFieldAndMassTest.cpp
@@ -30,9 +30,9 @@
 #include <string>
 using std::string;
 
-namespace sofa
+namespace beamadapter_test
 {
-using sofa::component::forcefield::AdaptiveBeamForceFieldAndMass;
+using namespace beamadapter;
 using sofa::component::statecontainer::MechanicalObject;
 using sofa::helper::system::thread::ctime_t;
 

--- a/BeamAdapter_test/component/mapping/BeamLengthMappingTest.cpp
+++ b/BeamAdapter_test/component/mapping/BeamLengthMappingTest.cpp
@@ -39,8 +39,11 @@ using sofa::simulation::SceneLoaderXML ;
 using sofa::simulation::Node ;
 using sofa::component::statecontainer::MechanicalObject ;
 
-namespace sofa {
-  namespace { // anonymous namespace
+
+namespace beamadapter_test
+{
+
+using namespace beamadapter;
 using namespace core;
 using namespace component;
 using type::Vec;
@@ -256,7 +259,7 @@ struct BeamLengthMappingTest : public sofa::mapping_test::Mapping_test<_BeamLeng
 // Define the list of types to instanciate. We do not necessarily need to test all combinations.
 using ::testing::Types;
 typedef Types<
-mapping::_beamlengthmapping_::BeamLengthMapping<defaulttype::Rigid3dTypes,defaulttype::Vec1dTypes>
+BeamLengthMapping<defaulttype::Rigid3dTypes,defaulttype::Vec1dTypes>
 //,mapping::_beamlengthmapping_::BeamLengthMapping<defaulttype::Rigid3fTypes,defaulttype::Vec1fTypes>
 > DataTypes; // the types to instanciate.
 
@@ -278,5 +281,4 @@ TYPED_TEST( BeamLengthMappingTest , DISABLED_testCase2 )
     ASSERT_TRUE(this->testCase2());
 }
 
-  }// anonymous namespace
-  }//sofa
+}

--- a/BeamAdapter_test/component/model/WireRestShape_test.cpp
+++ b/BeamAdapter_test/component/model/WireRestShape_test.cpp
@@ -35,7 +35,7 @@ using namespace sofa::testing;
 using namespace sofa::defaulttype;
 using namespace sofa::type;
 using namespace sofa::core::objectmodel;
-using namespace sofa::component::engine::_wirerestshape_;
+using namespace beamadapter;
 
 class WireRestShape_test : public BaseTest
 {

--- a/src/BeamAdapter/component/BaseBeamInterpolation.cpp
+++ b/src/BeamAdapter/component/BaseBeamInterpolation.cpp
@@ -28,13 +28,11 @@
 #include <sofa/core/ObjectFactory.h>
 
 
-namespace sofa::component::fem::_basebeaminterpolation_
+namespace beamadapter
 {
-using namespace sofa::defaulttype;
 
+using namespace sofa::defaulttype;
 
 template class SOFA_BEAMADAPTER_API BaseBeamInterpolation<Rigid3Types>;
 
-} // namespace sofa::component::fem::_basebeaminterpolation_
-
-
+} // namespace beamadapter

--- a/src/BeamAdapter/component/BaseBeamInterpolation.h
+++ b/src/BeamAdapter/component/BaseBeamInterpolation.h
@@ -39,11 +39,9 @@
 #include <sofa/component/statecontainer/MechanicalObject.h>
 
 
-namespace sofa::component::fem
+namespace beamadapter
 {
 
-namespace _basebeaminterpolation_
-{
 using sofa::core::topology::BaseMeshTopology ;
 using sofa::type::Quat ;
 using sofa::type::Vec ;
@@ -83,8 +81,6 @@ public:
     using EdgeID = BaseMeshTopology::EdgeID;
     using VecEdgeID = type::vector<BaseMeshTopology::EdgeID>;
     using VecEdges = type::vector<BaseMeshTopology::Edge>;
-
-    using BeamSection = sofa::beamadapter::BeamSection;
 
     BaseBeamInterpolation(/*sofa::component::engine::WireRestShape<DataTypes> *_restShape = nullptr*/);
 
@@ -245,9 +241,4 @@ public:
 extern template class SOFA_BEAMADAPTER_API BaseBeamInterpolation<sofa::defaulttype::Rigid3Types>;
 #endif
 
-} // namespace _basebeaminterpolation_
-
-/// Import the privately defined into the expected sofa namespace.
-using _basebeaminterpolation_::BaseBeamInterpolation ;
-
-} // namespace sofa::component::fem
+} // namespace beamadapter

--- a/src/BeamAdapter/component/BaseBeamInterpolation.inl
+++ b/src/BeamAdapter/component/BaseBeamInterpolation.inl
@@ -25,7 +25,7 @@
 #include <BeamAdapter/component/BeamInterpolation.inl>
 
 
-namespace sofa::component::fem::_basebeaminterpolation_
+namespace beamadapter
 {
 
 //using sofa::component::engine::WireRestShape ;
@@ -1018,5 +1018,4 @@ void BaseBeamInterpolation<DataTypes>::MapForceOnNodeUsingSpline(unsigned int ed
     FNode1output = DOF1Global_H_local1 * (f2 + f3);
 }
 
-} // namespace sofa::component::fem::_basebeaminterpolation_
-
+} // namespace beamadapter

--- a/src/BeamAdapter/component/BeamInterpolation.cpp
+++ b/src/BeamAdapter/component/BeamInterpolation.cpp
@@ -40,21 +40,15 @@
 /// Have a look a the end of BeamInterpolation.h
 #include <BeamAdapter/component/BeamInterpolation.inl>
 
-
-namespace sofa::component::fem::_beaminterpolation_
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API BeamInterpolation<sofa::defaulttype::Rigid3Types>;
 
-} // namespace sofa::component::fem::_beaminterpolation_
-
-namespace beamadapter
-{
-
 void registerBeamInterpolation(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Adaptive Beam Interpolation")
-                             .add< sofa::component::fem::_beaminterpolation_::BeamInterpolation<sofa::defaulttype::Rigid3Types> >());
+                             .add< BeamInterpolation<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/BeamInterpolation.h
+++ b/src/BeamAdapter/component/BeamInterpolation.h
@@ -39,12 +39,9 @@
 #include <sofa/helper/OptionsGroup.h>
 #include <sofa/component/statecontainer/MechanicalObject.h>
 
-namespace sofa::component::fem
+namespace beamadapter
 {
 
-namespace _beaminterpolation_
-{
-using sofa::component::fem::BaseBeamInterpolation;
 using sofa::helper::OptionsGroup;
 using sofa::core::topology::BaseMeshTopology;
 using sofa::core::behavior::MechanicalState;
@@ -94,7 +91,6 @@ public:
     using VecElementID = type::vector<BaseMeshTopology::EdgeID>;
     using VecEdges = type::vector<BaseMeshTopology::Edge>;    
 
-    using BeamSection = sofa::beamadapter::BeamSection;
     using BaseBeamInterpolation<DataTypes>::d_componentState;
 public:
     BeamInterpolation() ;
@@ -221,8 +217,4 @@ protected :
 extern template class SOFA_BEAMADAPTER_API BeamInterpolation<sofa::defaulttype::Rigid3Types>;
 #endif
 
-} /// namespace _beaminterpolation_
-
-using _beaminterpolation_::BeamInterpolation ;
-
-} /// namespace sofa::component::fem
+} // namespace beamadapter

--- a/src/BeamAdapter/component/BeamInterpolation.inl
+++ b/src/BeamAdapter/component/BeamInterpolation.inl
@@ -36,7 +36,7 @@
 #include <BeamAdapter/component/BaseBeamInterpolation.inl>
 
 
-namespace sofa::component::fem::_beaminterpolation_
+namespace beamadapter
 {
 
 #define BEAMADAPTER_WITH_VERIFICATION false
@@ -612,5 +612,4 @@ void BeamInterpolation<DataTypes>::updateInterpolation(){
 }
 
 
-} // namespace sofa::component::fem::_beaminterpolation_
-
+} // namespace beamadapter

--- a/src/BeamAdapter/component/WireBeamInterpolation.cpp
+++ b/src/BeamAdapter/component/WireBeamInterpolation.cpp
@@ -39,20 +39,15 @@
 #include <sofa/core/ObjectFactory.h>
 
 
-namespace sofa::component::fem::_wirebeaminterpolation_
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API WireBeamInterpolation<sofa::defaulttype::Rigid3Types>;
 
-} // namespace sofa::component::fem::_wirebeaminterpolation_
-
-namespace beamadapter
-{
-
 void registerWireBeamInterpolation(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Adaptive Beam Interpolation on Wire rest Shape")
-                             .add< sofa::component::fem::_wirebeaminterpolation_::WireBeamInterpolation<sofa::defaulttype::Rigid3Types> >());
+                             .add< WireBeamInterpolation<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/WireBeamInterpolation.h
+++ b/src/BeamAdapter/component/WireBeamInterpolation.h
@@ -49,12 +49,9 @@
 #include <sofa/core/objectmodel/BaseObject.h>
 
 
-namespace sofa::component::fem
+namespace beamadapter
 {
 
-namespace _wirebeaminterpolation_
-{
-using sofa::component::fem::BaseBeamInterpolation;
 using sofa::core::topology::BaseMeshTopology ;
 using sofa::type::Quat ;
 using sofa::type::Vec ;
@@ -95,9 +92,7 @@ public:
     typedef typename Inherited::Vec3 Vec3;
     typedef typename Inherited::Quat Quat;
 
-    using BeamSection = sofa::beamadapter::BeamSection;
-
-    WireBeamInterpolation(sofa::component::engine::WireRestShape<DataTypes> *_restShape = nullptr);
+    WireBeamInterpolation(WireRestShape<DataTypes> *_restShape = nullptr);
 
     virtual ~WireBeamInterpolation() = default;
 
@@ -164,7 +159,7 @@ public:
     void setControlled(bool value) { m_isControlled = value; }
 
 
-    SingleLink<WireBeamInterpolation<DataTypes>, sofa::component::engine::WireRestShape<DataTypes>,
+    SingleLink<WireBeamInterpolation<DataTypes>, WireRestShape<DataTypes>,
     BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> m_restShape; /*! link on an external rest-shape*/
 
 
@@ -207,9 +202,4 @@ protected:
 extern template class SOFA_BEAMADAPTER_API WireBeamInterpolation<sofa::defaulttype::Rigid3Types>;
 #endif
 
-} // namespace _wirebeaminterpolation_
-
-/// Import the privately defined into the expected sofa namespace.
-using _wirebeaminterpolation_::WireBeamInterpolation ;
-
-} // namespace sofa::component::fem
+} // namespace beamadapter

--- a/src/BeamAdapter/component/WireBeamInterpolation.inl
+++ b/src/BeamAdapter/component/WireBeamInterpolation.inl
@@ -36,14 +36,11 @@
 #include <BeamAdapter/component/BaseBeamInterpolation.inl>
 
 
-namespace sofa::component::fem::_wirebeaminterpolation_
+namespace beamadapter
 {
 
-using sofa::component::engine::WireRestShape ;
-using namespace sofa::beamadapter;
-
 template <class DataTypes>
-WireBeamInterpolation<DataTypes>::WireBeamInterpolation(sofa::component::engine::WireRestShape<DataTypes> *_restShape)
+WireBeamInterpolation<DataTypes>::WireBeamInterpolation(WireRestShape<DataTypes> *_restShape)
     : m_restShape(initLink("WireRestShape", "link to the component on the scene"), _restShape)
 {
 
@@ -302,6 +299,4 @@ typename T::SPtr  WireBeamInterpolation<DataTypes>::create(T* tObj, core::object
 }
 
 
-} // namespace sofa::component::fem::_wirebeaminterpolation_
-
-
+} // namespace beamadapter

--- a/src/BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.cpp
+++ b/src/BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.cpp
@@ -28,7 +28,7 @@
 #include <sofa/core/ObjectFactory.h>
 
 
-namespace sofa::component::constraintset::_adaptivebeamlengthconstraint_
+namespace beamadapter
 {
 
 
@@ -58,15 +58,10 @@ void AdaptiveBeamLengthConstraintResolution::store(int line, SReal* force, bool 
 
 template class AdaptiveBeamLengthConstraint<sofa::defaulttype::Rigid3Types>;
 
-} // namespace sofa::component::constraintset::_adaptivebeamlengthconstraint_
-
-namespace beamadapter
-{
-
 void registerAdaptiveBeamLengthConstraint(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Constrain the length of a beam.")
-                             .add< sofa::component::constraintset::_adaptivebeamlengthconstraint_::AdaptiveBeamLengthConstraint<sofa::defaulttype::Rigid3Types> >());
+                             .add< AdaptiveBeamLengthConstraint<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.h
+++ b/src/BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.h
@@ -31,24 +31,7 @@
 
 #include <BeamAdapter/component/WireBeamInterpolation.h>
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// Forward declarations, see https://en.wikipedia.org/wiki/Forward_declaration
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// Declarations
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace sofa::component::constraintset
-{
-
-/////////////////////////////////// private namespace pattern //////////////////////////////////////
-/// To avoid the lacking of names imported with with 'using' in the other's component namespace
-/// you should use a private namespace and "export" only this one in the public namespace.
-/// This is done at the end of this file, have a look if you are not used to this pattern.
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace _adaptivebeamlengthconstraint_
+namespace beamadapter
 {
 using sofa::core::behavior::ConstraintResolution ;
 using sofa::core::behavior::Constraint ;
@@ -153,7 +136,7 @@ protected:
     Data<Real>             m_constrainedLength ;
     Data<Real>             m_maxBendingAngle ;
     SingleLink<AdaptiveBeamLengthConstraint<DataTypes>,
-               fem::WireBeamInterpolation<DataTypes>,
+               WireBeamInterpolation<DataTypes>,
                BaseLink::FLAG_STOREPATH|BaseLink::FLAG_STRONGLINK> m_interpolation;
 
 private:
@@ -165,8 +148,4 @@ private:
 extern template class SOFA_BEAMADAPTER_API AdaptiveBeamLengthConstraint<defaulttype::Rigid3Types>;
 #endif
 
-} /// namespace _adaptivebeamlengthconstraint_
-
-using _adaptivebeamlengthconstraint_::AdaptiveBeamLengthConstraint ;
-
-} /// namespace sofa::component::constraintset
+} // namespace beamadapter

--- a/src/BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.inl
+++ b/src/BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.inl
@@ -30,7 +30,7 @@
 #include <BeamAdapter/component/constraint/AdaptiveBeamLengthConstraint.h>
 
 
-namespace sofa::component::constraintset::_adaptivebeamlengthconstraint_
+namespace beamadapter
 {
 
 using helper::ReadAccessor;
@@ -98,7 +98,7 @@ void AdaptiveBeamLengthConstraint<DataTypes>::detectElongation(const VecCoord& x
     Real alarmLength = m_alarmLength.getValue();
     bool prev_stretch = false;
 
-    fem::WireBeamInterpolation<DataTypes>* interpolation = m_interpolation.get();
+    auto* interpolation = m_interpolation.get();
 
     /// storage of the length (and the rest_length)  of the interval being stretched
     ///	length_interval=0.0; //commented to remove compilation warning
@@ -405,4 +405,4 @@ void AdaptiveBeamLengthConstraint<DataTypes>::draw(const VisualParams* vparams)
     vparams->drawTool()->restoreLastState();
 }
 
-} // namespace sofa::component::constraintset::_adaptivebeamlengthconstraint_
+} // namespace beamadapter

--- a/src/BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.cpp
+++ b/src/BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.cpp
@@ -39,7 +39,7 @@ using sofa::defaulttype::Rigid3Types;
 using sofa::defaulttype::Rigid3Types;
 
 
-namespace sofa::component::constraintset::_adaptiveBeamSlidingConstraint_
+namespace beamadapter
 {
 
 AdaptiveBeamSlidingConstraintResolution::AdaptiveBeamSlidingConstraintResolution(double* sliding)
@@ -79,18 +79,10 @@ void AdaptiveBeamSlidingConstraintResolution::store(int line, double* force, boo
 
 template class SOFA_BEAMADAPTER_API AdaptiveBeamSlidingConstraint<Rigid3Types>;
 
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
-} // namespace sofa::component::constraintset::_adaptiveBeamSlidingConstraint_
-
-namespace beamadapter
-{
-
 void registerAdaptiveBeamSlidingConstraint(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Constrain a rigid to be attached to a beam (only in position, not the orientation).")
-                             .add< sofa::component::constraintset::_adaptiveBeamSlidingConstraint_::AdaptiveBeamSlidingConstraint<Rigid3Types> >());
+                             .add< AdaptiveBeamSlidingConstraint<Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.h
+++ b/src/BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.h
@@ -26,15 +26,7 @@
 #include <BeamAdapter/component/WireBeamInterpolation.h>
 
 
-namespace sofa::component::constraintset
-{
-
-/////////////////////////////////// private namespace pattern //////////////////////////////////////
-/// To avoid the lacking of names imported with with 'using' in the other's component namespace
-/// you should use a private namespace and "export" only this one in the public namespace.
-/// This is done at the end of this file, have a look if you are not used to this pattern.
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace _adaptiveBeamSlidingConstraint_
+namespace beamadapter
 {
 
 using sofa::core::behavior::PairInteractionConstraint ;
@@ -45,19 +37,7 @@ using sofa::defaulttype::SolidTypes ;
 using sofa::linearalgebra::BaseVector ;
 using sofa::core::objectmodel::Data ;
 using sofa::type::Vec ;
-using sofa::component::fem::WireBeamInterpolation ;
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// Declarations
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/*!
- * \class AdaptiveBeamSlidingConstraint
- * @brief AdaptiveBeamSlidingConstraint Class constrain a rigid to be attached to a beam (only in position, not the orientation)
- *
- * More informations about SOFA components:
- * https://www.sofa-framework.org/community/doc/programming-with-sofa/create-your-component/
- * https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/components-and-datas/
- */
 template<class DataTypes>
 class SOFA_BEAMADAPTER_API AdaptiveBeamSlidingConstraint : public PairInteractionConstraint<DataTypes>
 {
@@ -204,10 +184,4 @@ public:
 extern template class SOFA_BEAMADAPTER_API AdaptiveBeamSlidingConstraint<defaulttype::Rigid3Types>;
 #endif
 
-} // namespace _adaptiveBeamSlidingConstraint_
-
-/// 'Export' the objects defined in the private namespace into the 'public' one so that
-/// we can use them instead as sofa::component::constraintset::AdaptiveBeamSlidingConstraint.
-using _adaptiveBeamSlidingConstraint_::AdaptiveBeamSlidingConstraint ;
-
-} // namespace sofa::component::constraintset
+} // namespace beamadapter

--- a/src/BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.inl
+++ b/src/BeamAdapter/component/constraint/AdaptiveBeamSlidingConstraint.inl
@@ -28,7 +28,7 @@
 #include <sofa/core/behavior/ConstraintResolution.h>
 
 
-namespace sofa::component::constraintset::_adaptiveBeamSlidingConstraint_
+namespace beamadapter
 {
 
 using sofa::core::behavior::ConstraintResolution ;
@@ -544,6 +544,6 @@ bool ProjectionSearch<DataTypes>::testForProjection(Real curvAbs)
 }
 
 
-} // namespace sofa::component::constraintset::_adaptiveBeamSlidingConstraint_
+} // namespace beamadapter
 
 

--- a/src/BeamAdapter/component/controller/AdaptiveBeamController.cpp
+++ b/src/BeamAdapter/component/controller/AdaptiveBeamController.cpp
@@ -41,22 +41,15 @@
 
 #include <BeamAdapter/component/controller/AdaptiveBeamController.inl>
 
-namespace sofa::component::controller::_adaptivebeamcontroller_
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API AdaptiveBeamController<sofa::defaulttype::Rigid3Types>;
 
-} // namespace sofa::component::controller::_adaptivebeamcontroller_
-
-namespace beamadapter
-{
-
 void registerAdaptiveBeamController(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Adaptive beam controller.")
-                             .add< sofa::component::controller::_adaptivebeamcontroller_::AdaptiveBeamController<sofa::defaulttype::Rigid3Types> >());
+                             .add< AdaptiveBeamController<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter
-
-

--- a/src/BeamAdapter/component/controller/AdaptiveBeamController.h
+++ b/src/BeamAdapter/component/controller/AdaptiveBeamController.h
@@ -48,21 +48,12 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Declarations
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace sofa::component::controller
-{
-
-/////////////////////////////////// private namespace pattern //////////////////////////////////////
-/// To avoid the lacking of names imported with with 'using' in the other's component namespace
-/// you should use a private namespace and "export" only this one in the public namespace.
-/// This is done at the end of this file, have a look if you are not used to this pattern.
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace _adaptivebeamcontroller_
+namespace beamadapter
 {
 
 using sofa::component::constraint::projective::FixedProjectiveConstraint;
 using sofa::component::topology::container::dynamic::EdgeSetTopologyModifier ;
 using sofa::component::topology::container::dynamic::EdgeSetGeometryAlgorithms ;
-using sofa::component::fem::BeamInterpolation ;
 using sofa::core::objectmodel::KeypressedEvent ;
 using sofa::core::objectmodel::MouseEvent ;
 using sofa::core::topology::BaseMeshTopology ;
@@ -85,11 +76,11 @@ using std::string;
  * https://www.sofa-framework.org/community/doc/programming-with-sofa/components-api/components-and-datas/
  */
 template<class DataTypes>
-class AdaptiveBeamController : public MechanicalStateController<DataTypes>
+class AdaptiveBeamController : public sofa::component::controller::MechanicalStateController<DataTypes>
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE(AdaptiveBeamController,DataTypes),
-               SOFA_TEMPLATE(MechanicalStateController,DataTypes));
+               SOFA_TEMPLATE(sofa::component::controller::MechanicalStateController,DataTypes));
 
     typedef typename DataTypes::VecCoord VecCoord;
     typedef typename DataTypes::VecDeriv VecDeriv;
@@ -98,9 +89,9 @@ public:
     typedef typename Coord::value_type   Real    ;
 
     typedef BaseMeshTopology::EdgeID ElementID;
-    typedef type::vector<BaseMeshTopology::EdgeID> VecElementID;
+    typedef sofa::type::vector<BaseMeshTopology::EdgeID> VecElementID;
 
-    typedef MechanicalStateController<DataTypes> Inherit;
+    typedef sofa::component::controller::MechanicalStateController<DataTypes> Inherit;
 
     typedef typename SolidTypes<Real>::Transform Transform;
     typedef typename SolidTypes<Real>::SpatialVector SpatialVector;
@@ -145,10 +136,4 @@ protected:
 extern template class SOFA_BEAMADAPTER_API AdaptiveBeamController<defaulttype::Rigid3Types>;
 #endif
 
-} /// namespace _adaptivebeamcontroller_
-
-
-/// 'Export' the objects defined in the private namespace into the 'public' one.
-using _adaptivebeamcontroller_::AdaptiveBeamController ;
-
-} /// namespace sofa::component::controller
+} // namespace beamadapter

--- a/src/BeamAdapter/component/controller/AdaptiveBeamController.inl
+++ b/src/BeamAdapter/component/controller/AdaptiveBeamController.inl
@@ -43,7 +43,7 @@
 #include <BeamAdapter/component/controller/AdaptiveBeamController.h>
 
 
-namespace sofa::component::controller::_adaptivebeamcontroller_
+namespace beamadapter
 {
 
 using sofa::core::objectmodel::BaseContext ;
@@ -319,6 +319,6 @@ void AdaptiveBeamController<DataTypes>::applyController()
     m_adaptiveinterpolation->setLength(newCurvAbs.size()-2,L);
 }
 
-} // namespace sofa::component::controller::_adaptivebeamcontroller_
+} // namespace beamadapter
 
 

--- a/src/BeamAdapter/component/controller/BeamAdapterActionController.cpp
+++ b/src/BeamAdapter/component/controller/BeamAdapterActionController.cpp
@@ -28,20 +28,15 @@
 
 #include <BeamAdapter/component/controller/BeamAdapterActionController.inl>
 
-namespace sofa::component::controller
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API BeamAdapterActionController<sofa::defaulttype::Rigid3Types>;
 
-} // namespace
-
-namespace beamadapter
-{
-
 void registerBeamAdapterActionController(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("BeamAdapterActionController")
-                                            .add< sofa::component::controller::BeamAdapterActionController<sofa::defaulttype::Rigid3Types> >());
+                                            .add< BeamAdapterActionController<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/controller/BeamAdapterActionController.h
+++ b/src/BeamAdapter/component/controller/BeamAdapterActionController.h
@@ -29,7 +29,7 @@
 #include <sofa/core/objectmodel/MouseEvent.h>
 #include <sofa/core/objectmodel/KeypressedEvent.h>
 
-namespace sofa::component::controller
+namespace beamadapter
 {
 
 /***
@@ -39,12 +39,11 @@ namespace sofa::component::controller
 * Otherwise, it will load a list of @sa BeamActions with their corresponding key times to replay a navigation. 
 */
 template<class DataTypes>
-class BeamAdapterActionController : public MechanicalStateController<DataTypes>
+class BeamAdapterActionController : public sofa::component::controller::MechanicalStateController<DataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(BeamAdapterActionController, DataTypes), SOFA_TEMPLATE(MechanicalStateController, DataTypes));
+    SOFA_CLASS(SOFA_TEMPLATE(BeamAdapterActionController, DataTypes), SOFA_TEMPLATE(sofa::component::controller::MechanicalStateController, DataTypes));
 
-    using BeamAdapterAction = sofa::beamadapter::BeamAdapterAction;
     using interventionCtrl = InterventionalRadiologyController<DataTypes>;
     using Real = typename DataTypes::Real;
 
@@ -83,4 +82,4 @@ private:
 extern template class SOFA_BEAMADAPTER_API BeamAdapterActionController<sofa::defaulttype::Rigid3Types>;
 #endif
 
-} /// namespace sofa::component::controller
+} // namespace beamadapter

--- a/src/BeamAdapter/component/controller/BeamAdapterActionController.inl
+++ b/src/BeamAdapter/component/controller/BeamAdapterActionController.inl
@@ -24,10 +24,8 @@
 #include <sofa/core/objectmodel/MouseEvent.h>
 #include <sofa/core/objectmodel/KeypressedEvent.h>
 
-namespace sofa::component::controller
+namespace beamadapter
 {
-
-using namespace sofa::beamadapter;
 
 template <class DataTypes>
 BeamAdapterActionController<DataTypes>::BeamAdapterActionController()
@@ -158,4 +156,4 @@ void BeamAdapterActionController<DataTypes>::onBeginAnimationStep(const double /
 }
 
 
-} // namespace sofa::component::controller
+} // namespace beamadapter

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.cpp
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.cpp
@@ -40,20 +40,15 @@
 #include <BeamAdapter/component/controller/InterventionalRadiologyController.inl>
 
 
-namespace sofa::component::controller::_interventionalradiologycontroller_
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API InterventionalRadiologyController<sofa::defaulttype::Rigid3Types>;
 
-} // namespace sofa::component::controller::_interventionalradiologycontroller_
-
-namespace beamadapter
-{
-
 void registerInterventionalRadiologyController(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Provides a Mouse & Keyboard user control on an EdgeSet Topology.")
-                             .add< sofa::component::controller::_interventionalradiologycontroller_::InterventionalRadiologyController<sofa::defaulttype::Rigid3Types> >());
+                             .add< InterventionalRadiologyController<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.h
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.h
@@ -46,10 +46,7 @@
 #include <sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.h>
 #include <sofa/component/topology/container/dynamic/EdgeSetTopologyModifier.h>
 
-namespace sofa::component::controller
-{
-
-namespace _interventionalradiologycontroller_
+namespace beamadapter
 {
 
 using sofa::type::Vec;
@@ -64,10 +61,10 @@ using sofa::component::constraint::projective::FixedProjectiveConstraint;
  * Provides a Mouse & Keyboard user control on an EdgeSet Topology.
  */
 template<class DataTypes>
-class InterventionalRadiologyController : public MechanicalStateController<DataTypes>
+class InterventionalRadiologyController : public sofa::component::controller::MechanicalStateController<DataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(InterventionalRadiologyController,DataTypes),SOFA_TEMPLATE(MechanicalStateController,DataTypes));
+    SOFA_CLASS(SOFA_TEMPLATE(InterventionalRadiologyController,DataTypes),SOFA_TEMPLATE(sofa::component::controller::MechanicalStateController,DataTypes));
     typedef typename DataTypes::VecCoord                            VecCoord;
     typedef typename DataTypes::VecDeriv                            VecDeriv;
     typedef typename DataTypes::Coord                               Coord   ;
@@ -80,8 +77,8 @@ public:
     typedef Vec<3, Real>                            Vec3;
     typedef BaseMeshTopology::EdgeID                ElementID;
     typedef type::vector<BaseMeshTopology::EdgeID>        VecElementID;
-    typedef MechanicalStateController<DataTypes>    Inherit;
-    typedef fem::WireBeamInterpolation<DataTypes>   WBeamInterpolation;
+    typedef sofa::component::controller::MechanicalStateController<DataTypes>    Inherit;
+    typedef WireBeamInterpolation<DataTypes>   WBeamInterpolation;
 
 public:
     InterventionalRadiologyController();
@@ -105,11 +102,11 @@ public:
     void interventionalRadiologyCollisionControls(type::vector<Real> &x_point_list,
                                                   type::vector<int> &id_instrument_list,
                                                   type::vector<int> &removeEdge);
-    void getInstrumentList(type::vector<sofa::component::fem::WireBeamInterpolation<DataTypes>*>& list);
+    void getInstrumentList(type::vector<WireBeamInterpolation<DataTypes>*>& list);
     const type::vector< type::vector<int> >& get_id_instrument_curvAbs_table()const;
     int getTotalNbEdges()const;
 
-    void applyAction(sofa::beamadapter::BeamAdapterAction action);
+    void applyAction(BeamAdapterAction action);
     /// Method to warn this controller that a BeamActionController is controlling the scene. Will bypass the event handling in this component.
     void useBeamAction(bool value) { m_useBeamActions = value; }
 
@@ -196,8 +193,4 @@ public:
 extern template class SOFA_BEAMADAPTER_API InterventionalRadiologyController<sofa::defaulttype::Rigid3Types>;
 #endif
 
-} // namespace _interventionalradiologycontroller_
-
-using _interventionalradiologycontroller_::InterventionalRadiologyController;
-
-} // namespace sofa::component::controller
+} // namespace beamadapter

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -45,7 +45,7 @@
 #include <BeamAdapter/component/controller/InterventionalRadiologyController.h>
 
 
-namespace sofa::component::controller::_interventionalradiologycontroller_
+namespace beamadapter
 {
 
 using type::vector;
@@ -53,7 +53,6 @@ using core::objectmodel::BaseContext;
 using helper::WriteAccessor;
 using core::objectmodel::KeypressedEvent;
 using core::objectmodel::MouseEvent;
-using namespace sofa::beamadapter;
 
 
 template <class DataTypes>
@@ -374,7 +373,7 @@ void InterventionalRadiologyController<DataTypes>::onBeginAnimationStep(const do
 
 
 template <class DataTypes>
-void InterventionalRadiologyController<DataTypes>::applyAction(sofa::beamadapter::BeamAdapterAction action)
+void InterventionalRadiologyController<DataTypes>::applyAction(BeamAdapterAction action)
 {
     int id = d_controlledInstrument.getValue();
     if (id >= int(m_instrumentsList.size()))
@@ -1058,7 +1057,7 @@ bool InterventionalRadiologyController<DataTypes>::modifyTopology(void)
 }
 
 template <class DataTypes>
-void InterventionalRadiologyController<DataTypes>::getInstrumentList(type::vector<fem::WireBeamInterpolation<DataTypes>*>& list)
+void InterventionalRadiologyController<DataTypes>::getInstrumentList(type::vector<WireBeamInterpolation<DataTypes>*>& list)
 {
     list = m_instrumentsList;
 }
@@ -1076,6 +1075,6 @@ int InterventionalRadiologyController<DataTypes>::getTotalNbEdges() const
 }
 
 
-} // namespace sofa::component::controller::_interventionalradiologycontroller_
+} // namespace beamadapter
 
 

--- a/src/BeamAdapter/component/controller/SutureController.cpp
+++ b/src/BeamAdapter/component/controller/SutureController.cpp
@@ -39,20 +39,15 @@
 #include <BeamAdapter/component/controller/SutureController.inl>
 
 
-namespace sofa::component::controller::_suturecontroller_
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API SutureController<sofa::defaulttype::Rigid3Types>;
 
-} // namespace
-
-namespace beamadapter
-{
-
 void registerSutureController(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Provides a Mouse & Keyboard user control on an EdgeSet Topology.")
-                             .add< sofa::component::controller::_suturecontroller_::SutureController<sofa::defaulttype::Rigid3Types> >());
+                             .add< SutureController<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/controller/SutureController.h
+++ b/src/BeamAdapter/component/controller/SutureController.h
@@ -50,13 +50,7 @@
 #include <sofa/component/topology/container/dynamic/EdgeSetTopologyModifier.h>
 #include <sofa/defaulttype/RigidTypes.h>
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////DECLARATIONS /////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace sofa::component::controller
-{
-
-namespace _suturecontroller_
+namespace beamadapter
 {
 
 using std::set ;
@@ -68,7 +62,6 @@ using sofa::defaulttype::SolidTypes ;
 using sofa::core::topology::TopologyContainer ;
 using sofa::core::CollisionModel ;
 using sofa::core::topology::BaseMeshTopology ;
-using sofa::component::fem::WireBeamInterpolation;
 using sofa::simulation::mechanicalvisitor::MechanicalProjectPositionAndVelocityVisitor;
 using sofa::simulation::mechanicalvisitor::MechanicalPropagateOnlyPositionAndVelocityVisitor;
 
@@ -79,11 +72,11 @@ using sofa::simulation::mechanicalvisitor::MechanicalPropagateOnlyPositionAndVel
  * Provides a Mouse & Keyboard user control on an EdgeSet Topology.
  */
 template<class DataTypes>
-class SutureController : public MechanicalStateController<DataTypes>
+class SutureController : public sofa::component::controller::MechanicalStateController<DataTypes>
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE(SutureController, DataTypes),
-               SOFA_TEMPLATE(MechanicalStateController, DataTypes));
+               SOFA_TEMPLATE(sofa::component::controller::MechanicalStateController, DataTypes));
 
     typedef typename DataTypes::VecCoord VecCoord;
     typedef typename DataTypes::VecDeriv VecDeriv;
@@ -247,8 +240,4 @@ private:
 #if !defined(SOFA_PLUGIN_BEAMADAPTER_SUTURECONTROLLER_CPP)
 extern template class SOFA_BEAMADAPTER_API SutureController<sofa::defaulttype::Rigid3Types>;
 #endif
-} /// namespace _suturecontroller_
-
-using _suturecontroller_::SutureController ;
-
-} /// namespace sofa::component::controller
+} // namespace beamadapter

--- a/src/BeamAdapter/component/controller/SutureController.inl
+++ b/src/BeamAdapter/component/controller/SutureController.inl
@@ -40,7 +40,7 @@
 #include <BeamAdapter/component/WireBeamInterpolation.h>
 
 
-namespace sofa::component::controller::_suturecontroller_
+namespace beamadapter
 {
 
 using sofa::core::objectmodel::BaseContext ;
@@ -1212,5 +1212,5 @@ void SutureController<DataTypes>::draw(const core::visual::VisualParams* vparams
     }
 }
 
-} // namespace sofa::component::controller::_suturecontroller_
+} // namespace beamadapter
 

--- a/src/BeamAdapter/component/engine/SteerableCatheter.cpp
+++ b/src/BeamAdapter/component/engine/SteerableCatheter.cpp
@@ -38,20 +38,15 @@
 #include <sofa/defaulttype/RigidTypes.h>
 
 
-namespace sofa::component::engine
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API SteerableCatheter<sofa::defaulttype::Rigid3Types>;
 
-}// namespace sofa::component::engine
-
-namespace beamadapter
-{
-
 void registerSteerableCatheter(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Catheter object with a flexible tip based on WireRestShape")
-                             .add< sofa::component::engine::SteerableCatheter<sofa::defaulttype::Rigid3Types> >());
+                             .add< SteerableCatheter<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/engine/SteerableCatheter.h
+++ b/src/BeamAdapter/component/engine/SteerableCatheter.h
@@ -43,7 +43,7 @@
 #include <sofa/core/objectmodel/KeyreleasedEvent.h>
 #include <sofa/simulation/AnimateBeginEvent.h>
 
-namespace sofa::component::engine
+namespace beamadapter
 {
 
 /*!
@@ -116,4 +116,4 @@ protected:
 extern template class SOFA_BEAMADAPTER_API SteerableCatheter<sofa::defaulttype::Rigid3Types>;
 #endif
 
-} // namespace sofa::component::engine
+} // namespace beamadapter

--- a/src/BeamAdapter/component/engine/SteerableCatheter.inl
+++ b/src/BeamAdapter/component/engine/SteerableCatheter.inl
@@ -35,7 +35,7 @@
 
 #include <math.h>
 
-namespace sofa::component::engine
+namespace beamadapter
 {
 
 template <class DataTypes>

--- a/src/BeamAdapter/component/engine/WireRestShape.cpp
+++ b/src/BeamAdapter/component/engine/WireRestShape.cpp
@@ -38,20 +38,15 @@
 #include <sofa/defaulttype/RigidTypes.h>
 
 
-namespace sofa::component::engine::_wirerestshape_
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API WireRestShape<sofa::defaulttype::Rigid3Types>;
 
-} // namespace sofa::component::engine::_wirerestshape_
-
-namespace beamadapter
-{
-
 void registerWireRestShape(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Describe the shape functions on multiple segments using curvilinear abscissa")
-                             .add< sofa::component::engine::_wirerestshape_::WireRestShape<sofa::defaulttype::Rigid3Types> >());
+                             .add< WireRestShape<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/engine/WireRestShape.h
+++ b/src/BeamAdapter/component/engine/WireRestShape.h
@@ -40,16 +40,11 @@
 #include <sofa/component/topology/container/dynamic/EdgeSetTopologyContainer.h>
 #include <sofa/core/loader/MeshLoader.h>
 
-namespace sofa::component::engine
-{
-
-namespace _wirerestshape_
+namespace beamadapter
 {
 
 using sofa::core::topology::TopologyContainer;
 using sofa::core::loader::MeshLoader;
-
-using namespace sofa::beamadapter;
 
 /**
  * \class WireRestShape
@@ -157,8 +152,4 @@ private:
 extern template class SOFA_BEAMADAPTER_API WireRestShape<sofa::defaulttype::Rigid3Types>;
 #endif
 
-} // namespace _wirerestshape_
-
-using _wirerestshape_::WireRestShape;
-
-} // namespace sofa::component::engine
+} // namespace beamadapter

--- a/src/BeamAdapter/component/engine/WireRestShape.inl
+++ b/src/BeamAdapter/component/engine/WireRestShape.inl
@@ -41,10 +41,7 @@
 #define EPSILON 0.0000000001
 #define VERIF 1
 
-namespace sofa::component::engine
-{
-
-namespace _wirerestshape_
+namespace beamadapter
 {
 
 using sofa::type::vector ;
@@ -368,7 +365,4 @@ void WireRestShape<DataTypes>::computeOrientation(const Vec3& AB, const Quat& Q,
 }
 
 
-} // namespace _wirerestshape_
-using _wirerestshape_::WireRestShape;
-
-} // namespace sofa::component::engine
+} // namespace beamadapter

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.cpp
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.cpp
@@ -39,20 +39,15 @@
 #include <BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl>
 
 
-namespace sofa::component::forcefield::_adaptivebeamforcefieldandmass_
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API AdaptiveBeamForceFieldAndMass<sofa::defaulttype::Rigid3Types>;
 
-} // namespace
-
-namespace beamadapter
-{
-
 void registerAdaptiveBeamForceFieldAndMass(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Adaptive Beam finite elements")
-                             .add< sofa::component::forcefield::_adaptivebeamforcefieldandmass_::AdaptiveBeamForceFieldAndMass<sofa::defaulttype::Rigid3Types> >());
+                             .add< AdaptiveBeamForceFieldAndMass<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
@@ -40,24 +40,7 @@
 #include <BeamAdapter/component/engine/WireRestShape.h>
 
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// Forward declarations, see https://en.wikipedia.org/wiki/Forward_declaration
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// Declarations
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace sofa::component::forcefield
-{
-
-/////////////////////////////////// private namespace pattern //////////////////////////////////////
-/// To avoid the lacking of names imported with with 'using' in the other's component namespace
-/// you should use a private namespace and "export" only this one in the public namespace.
-/// This is done at the end of this file, have a look if you are not used to this pattern.
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace _adaptivebeamforcefieldandmass_
+namespace beamadapter
 {
 
 using sofa::core::behavior::MultiMatrixAccessor;
@@ -97,8 +80,8 @@ public:
     using Transform = typename sofa::defaulttype::SolidTypes<Real>::Transform;
     using SpatialVector = typename sofa::defaulttype::SolidTypes<Real>::SpatialVector;
 
-    using BInterpolation = sofa::component::fem::BaseBeamInterpolation<DataTypes>;
-    using WireRestShape = sofa::component::engine::WireRestShape<DataTypes>;
+    using BInterpolation = BaseBeamInterpolation<DataTypes>;
+    using WireRestShape = WireRestShape<DataTypes>;
     using core::behavior::Mass<DataTypes>::mstate;
 
 protected:
@@ -218,13 +201,4 @@ private:
 extern template class SOFA_BEAMADAPTER_API AdaptiveBeamForceFieldAndMass<sofa::defaulttype::Rigid3Types> ;
 #endif
 
-} /// namespace _adaptivebeamforcefieldandmass_
-
-
-////////////////////////////////// EXPORT NAMES IN SOFA NAMESPACE //////////////////////////////////
-/// 'Export' the objects defined in the private namespace into the 'public' one.
-////////////////////////////////////////////////////////////////////////////////////////////////////
-using _adaptivebeamforcefieldandmass_::AdaptiveBeamForceFieldAndMass ;
-
-
-} /// namespace sofa::component::forcefield
+} // namespace beamadapter

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.h
@@ -81,7 +81,6 @@ public:
     using SpatialVector = typename sofa::defaulttype::SolidTypes<Real>::SpatialVector;
 
     using BInterpolation = BaseBeamInterpolation<DataTypes>;
-    using WireRestShape = WireRestShape<DataTypes>;
     using core::behavior::Mass<DataTypes>::mstate;
 
 protected:

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
@@ -42,10 +42,7 @@
 #include <sofa/helper/ScopedAdvancedTimer.h>
 
 
-namespace sofa::component::forcefield
-{
-
-namespace _adaptivebeamforcefieldandmass_
+namespace beamadapter
 {
 
 /* ************* ADAPTIVE FORCEFIELD_AND_MASS ************** */
@@ -823,6 +820,4 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::drawElement(const VisualParams *v
 }
 
 
-} /// namespace _adaptivebeamforcefieldandmass_
-
-} /// namespace sofa::component::forcefield
+} // namespace beamadapter

--- a/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.cpp
+++ b/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.cpp
@@ -39,20 +39,15 @@
 #include <BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.inl>
 
 
-namespace sofa::component::forcefield::_AdaptiveInflatableBeamForceField_
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API AdaptiveInflatableBeamForceField<sofa::defaulttype::Rigid3Types>;
 
-} // namespace sofa::component::forcefield::_AdaptiveInflatableBeamForceField_
-
-namespace beamadapter
-{
-
 void registerAdaptiveInflatableBeamForceField(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Adaptive Beam finite elements")
-                             .add< sofa::component::forcefield::_AdaptiveInflatableBeamForceField_::AdaptiveInflatableBeamForceField<sofa::defaulttype::Rigid3Types> >());
+                             .add< AdaptiveInflatableBeamForceField<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.h
+++ b/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.h
@@ -50,30 +50,10 @@
 #include <BeamAdapter/component/BeamInterpolation.h>
 #include <BeamAdapter/component/engine/WireRestShape.h>
 
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// Forward declarations, see https://en.wikipedia.org/wiki/Forward_declaration
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// Declarations
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace sofa::component::forcefield
-{
-
-/////////////////////////////////// private namespace pattern //////////////////////////////////////
-/// To avoid the lacking of names imported with with 'using' in the other's component namespace
-/// you should use a private namespace and "export" only this one in the public namespace.
-/// This is done at the end of this file, have a look if you are not used to this pattern.
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace _AdaptiveInflatableBeamForceField_
+namespace beamadapter
 {
 
 using sofa::type::vector;
-using sofa::component::engine::WireRestShape ;
-using sofa::component::fem::BeamInterpolation ;
 using sofa::core::behavior::MultiMatrixAccessor ;
 using sofa::core::visual::VisualParams ;
 using sofa::core::behavior::Mass ;
@@ -257,13 +237,4 @@ private:
 extern template class SOFA_BEAMADAPTER_API AdaptiveInflatableBeamForceField<Rigid3Types> ;
 #endif
 
-} /// namespace _AdaptiveInflatableBeamForceField_
-
-
-////////////////////////////////// EXPORT NAMES IN SOFA NAMESPACE //////////////////////////////////
-/// 'Export' the objects defined in the private namespace into the 'public' one.
-////////////////////////////////////////////////////////////////////////////////////////////////////
-using _AdaptiveInflatableBeamForceField_::AdaptiveInflatableBeamForceField ;
-
-
-} /// namespace sofa::component::forcefield
+} // namespace beamadapter

--- a/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveInflatableBeamForceField.inl
@@ -48,7 +48,7 @@
 #include <sofa/core/visual/VisualParams.h>
 
 
-namespace sofa::component::forcefield::_AdaptiveInflatableBeamForceField_
+namespace beamadapter
 {
 
 /* ************* ADAPTIVE FORCEFIELD_AND_MASS ************** */
@@ -807,5 +807,5 @@ void AdaptiveInflatableBeamForceField<DataTypes>::drawElement(const VisualParams
 }
 
 
-} // namespace sofa::component::forcefield::_AdaptiveInflatableBeamForceField_
+} // namespace beamadapter
 

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.cpp
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.cpp
@@ -41,7 +41,7 @@
 
 using namespace sofa::defaulttype;
 
-namespace sofa::component::mapping::_adaptivebeammapping_
+namespace beamadapter
 {
 
 using namespace core;
@@ -200,16 +200,11 @@ SOFA_BEAMADAPTER_API void AdaptiveBeamMapping<Rigid3Types, Rigid3Types >::comput
 template class SOFA_BEAMADAPTER_API AdaptiveBeamMapping<Rigid3Types, Vec3Types>;
 template class SOFA_BEAMADAPTER_API AdaptiveBeamMapping<Rigid3Types, Rigid3Types>;
 
-} // namespace sofa::component::mapping::_adaptivebeammapping_
-
-namespace beamadapter
-{
-
 void registerAdaptiveBeamMapping(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs.")
-                             .add< sofa::component::mapping::_adaptivebeammapping_::AdaptiveBeamMapping<Rigid3Types, Vec3Types   > >(true) //default template
-                             .add< sofa::component::mapping::_adaptivebeammapping_::AdaptiveBeamMapping<Rigid3Types, Rigid3Types > >());
+                             .add< AdaptiveBeamMapping<Rigid3Types, Vec3Types   > >(true) //default template
+                             .add< AdaptiveBeamMapping<Rigid3Types, Rigid3Types > >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.h
@@ -48,24 +48,7 @@
 #include <BeamAdapter/component/BaseBeamInterpolation.h>
 #include <BeamAdapter/component/controller/AdaptiveBeamController.h>
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// Forward declarations, see https://en.wikipedia.org/wiki/Forward_declaration
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// Declarations
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace sofa::component::mapping
-{
-
-/////////////////////////////////// private namespace pattern //////////////////////////////////////
-/// To avoid the lacking of names imported with with 'using' in the other's component namespace
-/// you should use a private namespace and "export" only this one in the public namespace.
-/// This is done at the end of this file, have a look if you are not used to this pattern.
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace _adaptivebeammapping_
+namespace beamadapter
 {
 
 using sofa::core::State ;
@@ -74,7 +57,6 @@ using sofa::type::Vec;
 using sofa::type::Mat;
 using sofa::core::topology::BaseMeshTopology;
 using defaulttype::SolidTypes;
-using sofa::component::fem::BaseBeamInterpolation;
 using core::MechanicalParams;
 using core::ConstraintParams;
 using core::visual::VisualParams;
@@ -241,8 +223,4 @@ extern template class SOFA_BEAMADAPTER_API AdaptiveBeamMapping<defaulttype::Rigi
 extern template class SOFA_BEAMADAPTER_API AdaptiveBeamMapping<defaulttype::Rigid3Types, defaulttype::Rigid3Types>;
 #endif
 
-} /// _adaptivebeammapping_
-
-using _adaptivebeammapping_::AdaptiveBeamMapping ;
-
-} /// namespace sofa::component::mapping
+} // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/AdaptiveBeamMapping.inl
@@ -47,10 +47,7 @@
 #include <sofa/simulation/ParallelForEach.h>
 #include <sofa/simulation/MainTaskSchedulerFactory.h>
 
-namespace sofa::component::mapping
-{
-
-namespace _adaptivebeammapping_
+namespace beamadapter
 {
 
 using sofa::core::State;
@@ -812,6 +809,4 @@ void AdaptiveBeamMapping< TIn, TOut>::applyJTonPoint(unsigned int i, const Deriv
     l_adaptativebeamInterpolation->MapForceOnNodeUsingSpline(pointBeamDistribution.beamId, pointBeamDistribution.baryPoint[0], localPos, x, Fin, FNode0output, FNode1output );
 }
 
-} /// namespace _adaptivebeammapping_
-
-} /// namespace sofa::component::mapping
+} // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/BeamLengthMapping.cpp
+++ b/src/BeamAdapter/component/mapping/BeamLengthMapping.cpp
@@ -40,23 +40,15 @@
 #include <BeamAdapter/component/mapping/BeamLengthMapping.inl>
 
 
-namespace sofa::component::mapping
-{
-
-namespace _beamlengthmapping_
-{
-    template class SOFA_BEAMADAPTER_API BeamLengthMapping<sofa::defaulttype::Rigid3Types, sofa::defaulttype::Vec1Types>;
-}
-
-} // namespace sofa::component::mapping
-
 namespace beamadapter
 {
+
+template class SOFA_BEAMADAPTER_API BeamLengthMapping<sofa::defaulttype::Rigid3Types, sofa::defaulttype::Vec1Types>;
 
 void registerBeamLengthMapping(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Compute the lengths of the beams.")
-                             .add< sofa::component::mapping::BeamLengthMapping<sofa::defaulttype::Rigid3Types, sofa::defaulttype::Vec1Types> >());
+                             .add< BeamLengthMapping<sofa::defaulttype::Rigid3Types, sofa::defaulttype::Vec1Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/BeamLengthMapping.h
+++ b/src/BeamAdapter/component/mapping/BeamLengthMapping.h
@@ -30,8 +30,7 @@
 // Copyright: See COPYING file that comes with this distribution
 //
 //
-#ifndef SOFA_COMPONENT_MAPPING_BEAMLENGTHMAPPING_H
-#define SOFA_COMPONENT_MAPPING_BEAMLENGTHMAPPING_H
+#pragma once
 
 //////////////////////// Inclusion of headers...from wider to narrower/closer //////////////////////
 #include <sofa/type/vector.h>
@@ -50,29 +49,9 @@
 
 #include <sofa/linearalgebra/EigenSparseMatrix.h>
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// Forward declarations, see https://en.wikipedia.org/wiki/Forward_declaration
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// Declarations
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-namespace sofa::component::mapping
+namespace beamadapter
 {
 
-/////////////////////////////////// private namespace pattern //////////////////////////////////////
-/// To avoid the lacking of names imported with with 'using' in the other's component namespace
-/// you should use a private namespace and "export" only this one in the public namespace.
-/// This is done at the end of this file, have a look if you are not used to this pattern.
-////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace _beamlengthmapping_
-{
-
-using namespace sofa::component::fem;
 using namespace sofa::core::objectmodel;
 
 using sofa::core::State ;
@@ -82,7 +61,6 @@ using sofa::type::Mat;
 using sofa::core::topology::BaseMeshTopology;
 using defaulttype::SolidTypes;
 using std::pair;
-using sofa::component::fem::BeamInterpolation;
 using sofa::type::vector;
 using std::string;
 using core::MechanicalParams;
@@ -228,11 +206,4 @@ public:
 extern template class SOFA_BEAMADAPTER_API BeamLengthMapping<defaulttype::Rigid3Types, defaulttype::Vec1Types   >;
 #endif
 
-} /// _beamlengthmapping_
-
-using _beamlengthmapping_::BeamLengthMapping ;
-
-
-
-} // namespace sofa::component::mapping
-#endif  /* SOFA_COMPONENT_MAPPING_BEAMLENGTHMAPPING_H */
+} // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/BeamLengthMapping.inl
+++ b/src/BeamAdapter/component/mapping/BeamLengthMapping.inl
@@ -30,8 +30,7 @@
 // Copyright: See COPYING file that comes with this distribution
 //
 //
-#ifndef SOFA_COMPONENT_MAPPING_BEAMLENGTHMAPPING_INL
-#define SOFA_COMPONENT_MAPPING_BEAMLENGTHMAPPING_INL
+#pragma once
 
 //////////////////////// Inclusion of headers...from wider to narrower/closer //////////////////////
 #include <BeamAdapter/component/mapping/BeamLengthMapping.h>
@@ -46,16 +45,7 @@
 #include <iomanip>
 
 
-namespace sofa
-{
-
-namespace component
-{
-
-namespace mapping
-{
-
-namespace _beamlengthmapping_
+namespace beamadapter
 {
 
 using namespace sofa::defaulttype;
@@ -946,9 +936,6 @@ void BeamLengthMapping<TIn, TOut>::computeDJtSpline(const Real &f_input, const V
     }
 }
 
-
-
-
 template <class TIn, class TOut>
 void BeamLengthMapping< TIn, TOut>::draw(const VisualParams* vparams)
 {
@@ -956,13 +943,4 @@ void BeamLengthMapping< TIn, TOut>::draw(const VisualParams* vparams)
         return;
 }
 
-
-} /// namespace _beamlengthmapping_
-
-} /// namespace mapping
-
-} /// namespace component
-
-} /// namespace sofa
-
-#endif  /* SOFA_COMPONENT_MAPPING_ADAPTIVEBEAMMAPPING_INL */
+} // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/BeamProjectionDifferenceMultiMapping.cpp
+++ b/src/BeamAdapter/component/mapping/BeamProjectionDifferenceMultiMapping.cpp
@@ -31,7 +31,7 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/core/ObjectFactory.h>
 
-namespace beamadapter::mapping
+namespace beamadapter
 {
 
 void registerBeamProjectionDifferenceMultiMapping(sofa::core::ObjectFactory* factory)
@@ -42,4 +42,4 @@ void registerBeamProjectionDifferenceMultiMapping(sofa::core::ObjectFactory* fac
 
 template class SOFA_BEAMADAPTER_API BeamProjectionDifferenceMultiMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types >;
 
-} // namespace beamadapter::mapping
+} // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/BeamProjectionDifferenceMultiMapping.h
+++ b/src/BeamAdapter/component/mapping/BeamProjectionDifferenceMultiMapping.h
@@ -38,8 +38,9 @@
 #include <BeamAdapter/config.h>
 
 
-namespace beamadapter::mapping
+namespace beamadapter
 {
+
 using sofa::defaulttype::SolidTypes ;
 using sofa::type::Matrix3;
 using sofa::type::Matrix4;
@@ -165,7 +166,7 @@ public:
     sofa::Data<Real> d_drawSize;
 
     sofa::SingleLink<BeamProjectionDifferenceMultiMapping<TIn1, TIn2, TOut>, sofa::core::topology::BaseMeshTopology, sofa::BaseLink::FLAG_STOREPATH | sofa::BaseLink::FLAG_STRONGLINK> l_in2Topology;
-    sofa::SingleLink<BeamProjectionDifferenceMultiMapping<TIn1, TIn2, TOut>, sofa::component::fem::BeamInterpolation<TIn2>, sofa::BaseLink::FLAG_STOREPATH | sofa::BaseLink::FLAG_STRONGLINK> l_interpolation;
+    sofa::SingleLink<BeamProjectionDifferenceMultiMapping<TIn1, TIn2, TOut>, BeamInterpolation<TIn2>, sofa::BaseLink::FLAG_STOREPATH | sofa::BaseLink::FLAG_STRONGLINK> l_interpolation;
 
     using sofa::core::Multi2Mapping<TIn1, TIn2, TOut>::d_componentState ;
 
@@ -202,4 +203,4 @@ private:
 extern template class SOFA_BEAMADAPTER_API BeamProjectionDifferenceMultiMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types, sofa::defaulttype::Rigid3Types >;
 #endif
 
-} // namespace
+} // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/BeamProjectionDifferenceMultiMapping.inl
+++ b/src/BeamAdapter/component/mapping/BeamProjectionDifferenceMultiMapping.inl
@@ -39,8 +39,9 @@
 
 #include <string>
 
-namespace beamadapter::mapping
+namespace beamadapter
 {
+
 using sofa::core::objectmodel::BaseContext ;
 using sofa::helper::WriteAccessor;
 using sofa::type::RGBAColor ;
@@ -560,4 +561,4 @@ void BeamProjectionDifferenceMultiMapping<TIn1, TIn2, TOut>::draw(const sofa::co
     }
 }
 
-} // namespace
+} // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.cpp
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.cpp
@@ -35,20 +35,15 @@
 #include <BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl>
 #include <sofa/core/ObjectFactory.h>
 
-namespace sofa::component::mapping
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API MultiAdaptiveBeamMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Vec3Types >;
 
-} // namespace sofa::component::mapping
-
-namespace beamadapter
-{
-
 void registerMultiAdaptiveBeamMapping(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Set the positions and velocities of points attached to a beam using linear interpolation between DOFs.")
-                             .add< sofa::component::mapping::MultiAdaptiveBeamMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Vec3Types > >());
+                             .add< MultiAdaptiveBeamMapping< sofa::defaulttype::Rigid3Types, sofa::defaulttype::Vec3Types > >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.h
@@ -36,7 +36,7 @@
 #include <BeamAdapter/component/controller/InterventionalRadiologyController.h>
 #include <BeamAdapter/component/mapping/AdaptiveBeamMapping.h>
 
-namespace sofa::component::mapping
+namespace beamadapter
 {
 
 /*!
@@ -84,7 +84,7 @@ public:
     typedef sofa::type::Mat<12,6,Real> Mat12x6;
 
     typedef std::pair<unsigned int, Vec3> BeamIdAndBaryCoord;
-    typedef sofa::component::controller::InterventionalRadiologyController<TIn> TInterventionalRadiologyController;
+    typedef InterventionalRadiologyController<TIn> TInterventionalRadiologyController;
 
 public:
     Data<bool> useCurvAbs;
@@ -140,7 +140,7 @@ protected:
     void assignSubMappingFromControllerInfo();
 
     // for fromSeveralInterpolations option
-    sofa::type::vector< sofa::component::fem::WireBeamInterpolation<TIn>  *> m_instrumentList;
+    sofa::type::vector< WireBeamInterpolation<TIn>  *> m_instrumentList;
     sofa::type::vector<  typename AdaptiveBeamMapping<TIn, TOut>::SPtr > m_subMappingList;
     TInterventionalRadiologyController* m_ircontroller;
     sofa::component::topology::container::dynamic::EdgeSetTopologyModifier* _edgeMod{nullptr};
@@ -155,4 +155,4 @@ protected:
 extern template class SOFA_BEAMADAPTER_API MultiAdaptiveBeamMapping<defaulttype::Rigid3Types, defaulttype::Vec3Types>;
 #endif
 
-} // namespace sofa::component::mapping
+} // namespace beamadapter

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
@@ -39,7 +39,7 @@
 #include <sofa/helper/ScopedAdvancedTimer.h>
 
 
-namespace sofa::component::mapping
+namespace beamadapter
 {
 
 using sofa::helper::ScopedAdvancedTimer;
@@ -392,7 +392,7 @@ int MultiAdaptiveBeamMapping< TIn, TOut>::addBaryPoint(const int& edgeId,const V
     {
         int controledEdgeId = edgeId-nbUnControlledEdges;
         const sofa::type::vector<int>&  id_instrument_table_on_node = id_instrument_curvAbs_table[controledEdgeId+1];
-        sofa::type::vector< sofa::component::fem::WireBeamInterpolation<In>  *> m_instrumentsList;
+        sofa::type::vector< WireBeamInterpolation<In>  *> m_instrumentsList;
         m_ircontroller->getInstrumentList(m_instrumentsList);
         Real radius = m_instrumentsList[id_instrument_table_on_node[0]]->getBeamSection(controledEdgeId)._r;
         int idInstrument  = id_instrument_table_on_node[0];
@@ -419,4 +419,4 @@ void MultiAdaptiveBeamMapping< TIn, TOut>::clear(int size)
 }
 
 
-} // namespace sofa::component::mapping
+} // namespace beamadapter

--- a/src/BeamAdapter/component/model/BaseRodSectionMaterial.cpp
+++ b/src/BeamAdapter/component/model/BaseRodSectionMaterial.cpp
@@ -24,11 +24,11 @@
 #include <BeamAdapter/component/model/BaseRodSectionMaterial.inl>
 #include <sofa/defaulttype/RigidTypes.h>
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
 
 using namespace sofa::defaulttype;
 
 template class SOFA_BEAMADAPTER_API BaseRodSectionMaterial<Rigid3Types>;
 
-}// namespace sofa::beamadapter
+}// namespace beamadapter

--- a/src/BeamAdapter/component/model/BaseRodSectionMaterial.h
+++ b/src/BeamAdapter/component/model/BaseRodSectionMaterial.h
@@ -28,7 +28,7 @@
 #include <sofa/component/topology/container/dynamic/EdgeSetTopologyModifier.h>
 #include <sofa/core/loader/MeshLoader.h>
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
 
 using sofa::core::loader::MeshLoader;
@@ -123,4 +123,4 @@ private:
 extern template class SOFA_BEAMADAPTER_API BaseRodSectionMaterial<sofa::defaulttype::Rigid3Types>;
 #endif
 
-} // namespace sofa::beamadapter
+} // namespace beamadapter

--- a/src/BeamAdapter/component/model/BaseRodSectionMaterial.inl
+++ b/src/BeamAdapter/component/model/BaseRodSectionMaterial.inl
@@ -23,7 +23,7 @@
 
 #include <BeamAdapter/component/model/BaseRodSectionMaterial.h>
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
 
 template <class DataTypes>
@@ -88,4 +88,4 @@ void BaseRodSectionMaterial<DataTypes>::getMechanicalParameters(Real& youngModul
     massDensity = this->d_massDensity.getValue();
 }
 
-} // namespace sofa::beamadapter
+} // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodMeshSection.cpp
+++ b/src/BeamAdapter/component/model/RodMeshSection.cpp
@@ -26,20 +26,15 @@
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/defaulttype/RigidTypes.h>
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API RodMeshSection<sofa::defaulttype::Rigid3Types>;
 
-}// namespace sofa::beamadapter
-
-namespace beamadapter
-{
-
 void registerRodMeshSection(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Class defining a Rod Section using a MeshLoader and material parameters.")
-                             .add< sofa::beamadapter::RodMeshSection<sofa::defaulttype::Rigid3Types> >());
+                             .add< RodMeshSection<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodMeshSection.h
+++ b/src/BeamAdapter/component/model/RodMeshSection.h
@@ -25,7 +25,7 @@
 #include <BeamAdapter/component/model/BaseRodSectionMaterial.h>
 #include <sofa/core/loader/MeshLoader.h>
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
 
 using sofa::core::loader::MeshLoader;
@@ -40,7 +40,7 @@ using sofa::core::loader::MeshLoader;
  * Method @sa getRestTransformOnX will return the current position of the curviline abscisse along the mesh structure.
  */
 template <class DataTypes>
-class RodMeshSection : public sofa::beamadapter::BaseRodSectionMaterial<DataTypes>
+class RodMeshSection : public BaseRodSectionMaterial<DataTypes>
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE(RodMeshSection, DataTypes), SOFA_TEMPLATE(BaseRodSectionMaterial, DataTypes));
@@ -88,4 +88,4 @@ private:
 extern template class SOFA_BEAMADAPTER_API RodMeshSection<sofa::defaulttype::Rigid3Types>;
 #endif
 
-} // namespace sofa::beamadapter
+} // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodMeshSection.inl
+++ b/src/BeamAdapter/component/model/RodMeshSection.inl
@@ -27,7 +27,7 @@
 
 #define EPSILON 0.0001
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
 
 template <class DataTypes>
@@ -295,4 +295,4 @@ void RodMeshSection<DataTypes>::rotateFrameForAlignX(const Quat& input, type::Ve
 
 
 
-} // namespace sofa::beamadapter
+} // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodSpireSection.cpp
+++ b/src/BeamAdapter/component/model/RodSpireSection.cpp
@@ -27,20 +27,15 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API RodSpireSection<sofa::defaulttype::Rigid3Types>;
 
-}// namespace sofa::beamadapter
-
-namespace beamadapter
-{
-
 void registerRodSpireSection(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Class defining a rod spire section, defining material and geometry parameters.")
-                             .add< sofa::beamadapter::RodSpireSection<sofa::defaulttype::Rigid3Types> >());
+                             .add< RodSpireSection<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodSpireSection.h
+++ b/src/BeamAdapter/component/model/RodSpireSection.h
@@ -24,7 +24,7 @@
 #include <BeamAdapter/config.h>
 #include <BeamAdapter/component/model/BaseRodSectionMaterial.h>
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
 
 using sofa::core::loader::MeshLoader;
@@ -38,7 +38,7 @@ using sofa::core::loader::MeshLoader;
  * Method @sa getRestTransformOnX will return the current position of the curviline abscisse along the spire.
  */
 template <class DataTypes>
-class RodSpireSection : public sofa::beamadapter::BaseRodSectionMaterial<DataTypes>
+class RodSpireSection : public BaseRodSectionMaterial<DataTypes>
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE(RodSpireSection, DataTypes), SOFA_TEMPLATE(BaseRodSectionMaterial, DataTypes));
@@ -66,4 +66,4 @@ public:
 extern template class SOFA_BEAMADAPTER_API RodSpireSection<sofa::defaulttype::Rigid3Types>;
 #endif
 
-} // namespace sofa::beamadapter
+} // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodSpireSection.inl
+++ b/src/BeamAdapter/component/model/RodSpireSection.inl
@@ -25,7 +25,7 @@
 #include <BeamAdapter/component/model/BaseRodSectionMaterial.inl>
 #include <sofa/core/objectmodel/BaseObject.h>
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
 
 template <class DataTypes>
@@ -94,4 +94,4 @@ void RodSpireSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, 
     global_H_local.set(SpirePos, newSpireQuat);    
 }
 
-} // namespace sofa::beamadapter
+} // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodStraightSection.cpp
+++ b/src/BeamAdapter/component/model/RodStraightSection.cpp
@@ -28,20 +28,15 @@
 
 #include <BeamAdapter/component/model/BaseRodSectionMaterial.inl>
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
 
 template class SOFA_BEAMADAPTER_API RodStraightSection<sofa::defaulttype::Rigid3Types>;
 
-}// namespace sofa::beamadapter
-
-namespace beamadapter
-{
-
 void registerRodStraightSection(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Class defining a rod straight section Material, defining material and geometry parameters.")
-                             .add< sofa::beamadapter::RodStraightSection<sofa::defaulttype::Rigid3Types> >());
+                             .add< RodStraightSection<sofa::defaulttype::Rigid3Types> >());
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodStraightSection.h
+++ b/src/BeamAdapter/component/model/RodStraightSection.h
@@ -24,7 +24,7 @@
 #include <BeamAdapter/config.h>
 #include <BeamAdapter/component/model/BaseRodSectionMaterial.h>
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
 
 /**
@@ -35,7 +35,7 @@ namespace sofa::beamadapter
  * Method @sa getRestTransformOnX will return: Vec3(current_x, 0 0)
  */
 template <class DataTypes>
-class RodStraightSection : public sofa::beamadapter::BaseRodSectionMaterial<DataTypes>
+class RodStraightSection : public BaseRodSectionMaterial<DataTypes>
 {
 public:
     SOFA_CLASS(SOFA_TEMPLATE(RodStraightSection, DataTypes), SOFA_TEMPLATE(BaseRodSectionMaterial, DataTypes));
@@ -59,4 +59,4 @@ protected:
 extern template class SOFA_BEAMADAPTER_API RodStraightSection<sofa::defaulttype::Rigid3Types>;
 #endif
 
-} // namespace sofa::beamadapter
+} // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodStraightSection.inl
+++ b/src/BeamAdapter/component/model/RodStraightSection.inl
@@ -25,7 +25,7 @@
 #include <BeamAdapter/component/model/BaseRodSectionMaterial.inl>
 #include <sofa/core/objectmodel/BaseObject.h>
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
 
 template <class DataTypes>
@@ -70,4 +70,4 @@ void RodStraightSection<DataTypes>::getRestTransformOnX(Transform& global_H_loca
 }
 
 
-} // namespace sofa::beamadapter
+} // namespace beamadapter

--- a/src/BeamAdapter/config.h.in
+++ b/src/BeamAdapter/config.h.in
@@ -38,3 +38,5 @@ namespace beamadapter
     constexpr const char* MODULE_NAME = "@PROJECT_NAME@";
     constexpr const char* MODULE_VERSION = "@PROJECT_VERSION@";
 } // namespace beamadapter
+
+using namespace sofa;

--- a/src/BeamAdapter/initBeamAdapter.cpp
+++ b/src/BeamAdapter/initBeamAdapter.cpp
@@ -45,20 +45,7 @@ extern void registerMultiAdaptiveBeamMapping(sofa::core::ObjectFactory* factory)
 extern void registerRodMeshSection(sofa::core::ObjectFactory* factory);
 extern void registerRodSpireSection(sofa::core::ObjectFactory* factory);
 extern void registerRodStraightSection(sofa::core::ObjectFactory* factory);
-
-namespace mapping
-{
-
 extern void registerBeamProjectionDifferenceMultiMapping(sofa::core::ObjectFactory* factory);
-
-} // namespace mapping
-
-} // namespace beamadapter
-
-namespace sofa::component
-{
-
-using namespace beamadapter;
 
 extern "C" {
     SOFA_BEAMADAPTER_API void initExternalModule();
@@ -128,7 +115,7 @@ void registerObjects(sofa::core::ObjectFactory* factory)
     registerRodMeshSection(factory);
     registerRodSpireSection(factory);
     registerRodStraightSection(factory);
-    mapping::registerBeamProjectionDifferenceMultiMapping(factory);
+    registerBeamProjectionDifferenceMultiMapping(factory);
 }
 
-} // namespace sofa::component
+} // namespace beamadapter

--- a/src/BeamAdapter/initBeamAdapter.h
+++ b/src/BeamAdapter/initBeamAdapter.h
@@ -22,9 +22,9 @@
 #pragma once
 #include <BeamAdapter/config.h>
 
-namespace sofa::component
+namespace beamadapter
 {
 
 void SOFA_BEAMADAPTER_API initBeamAdapter();
 
-} // namespace sofa::component
+} // namespace beamadapter

--- a/src/BeamAdapter/utils/BeamActions.h
+++ b/src/BeamAdapter/utils/BeamActions.h
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
     
     /// \brief Enum class listing all possible actions during Beam navigation
@@ -65,4 +65,4 @@ namespace sofa::beamadapter
             return BeamAdapterAction::NO_ACTION;
     }
 
-} // namespace sofa::beamAdapter
+} // namespace beamadapter

--- a/src/BeamAdapter/utils/BeamSection.h
+++ b/src/BeamAdapter/utils/BeamSection.h
@@ -22,7 +22,7 @@
 #pragma once
 
 
-namespace sofa::beamadapter
+namespace beamadapter
 {
     struct BeamSection {
         double _r{}; 			///< Radius of the beam section
@@ -35,4 +35,4 @@ namespace sofa::beamadapter
         double _Asz{}; 		    ///< _Asz is the z-direction effective shear area
     };
 
-} // namespace sofa::beamAdapter
+} // namespace beamadapter


### PR DESCRIPTION
Like stated in
-  #162

The namespaces are inconsistent (like... very), so this PR uniformizes the namespace across the plugin,
My takes (could be revised):
- everything under "beamadapter" namespace (no sofa behind)
- for now, no sub namespaces to reflect the folder hierarchy. It can be done but even the folder names are really not relevant.
- for simplifying everything, I set `use namespace sofa;` in the config.h file (i.e everywhere). it is a bold take, I could understand not doing that.