### PR TITLE
[All] Clean types

### DIFF
--- a/BeamAdapter_test/component/model/WireRestShape_test.cpp
+++ b/BeamAdapter_test/component/model/WireRestShape_test.cpp
@@ -163,10 +163,10 @@ void WireRestShape_test::testParameterInit()
     Real straightLength = 95.0;
     EXPECT_EQ(fullLength, 100.0);
 
-    int nbrE0 = 50;
-    int nbrE1 = 10;
+    sofa::Size nbrE0 = 50;
+    sofa::Size nbrE1 = 10;
     vector<Real> keysPoints, keysPoints_ref = { 0, straightLength, fullLength };
-    vector<int> nbP_density, nbP_density_ref = { nbrE0, nbrE1 };
+    vector<sofa::Size> nbP_density, nbP_density_ref = { nbrE0, nbrE1 };
     
     wire->getSamplingParameters(keysPoints, nbP_density);
     EXPECT_EQ(keysPoints.size(), 3);

--- a/src/BeamAdapter/component/BaseBeamInterpolation.h
+++ b/src/BeamAdapter/component/BaseBeamInterpolation.h
@@ -90,7 +90,7 @@ public:
 
     static void getControlPointsFromFrame(
         const Transform& global_H_local0, const Transform& global_H_local1,
-        const Real& L,
+        const Real L,
         Vec3& P0, Vec3& P1,
         Vec3& P2, Vec3& P3);
 
@@ -103,99 +103,98 @@ public:
     virtual void clear();
 
 public:
-    virtual void addBeam(const BaseMeshTopology::EdgeID& eID, const Real& length, const Real& x0, const Real& x1, const Real& angle);
-    unsigned int getNumBeams() { return this->d_edgeList.getValue().size(); }
+    virtual void addBeam(const EdgeID eID, const Real length, const Real x0, const Real x1, const Real angle);
+    sofa::Size getNumBeams() const { return static_cast<sofa::Size>(this->d_edgeList.getValue().size()); }
     
-    void getAbsCurvXFromBeam(int beam, Real& x_curv);
-    void getAbsCurvXFromBeam(int beam, Real& x_curv_start, Real& x_curv_end);
+    void getAbsCurvXFromBeam(const sofa::Index beam, Real& x_curv);
+    void getAbsCurvXFromBeam(const sofa::Index beam, Real& x_curv_start, Real& x_curv_end);
 
     /// getLength / setLength => provides the rest length of each spline using @sa d_lengthList
     virtual Real getRestTotalLength() = 0;
-    Real getLength(unsigned int edgeInList);
-    void setLength(unsigned int edgeInList, Real& length);
+    Real getLength(const EdgeID edgeInList);
+    void setLength(const EdgeID edgeInList, Real& length);
     
     /// Collision information using @sa d_beamCollision
-    virtual void getCollisionSampling(Real& dx, const Real& x_localcurv_abs) = 0;
-    void addCollisionOnBeam(unsigned int b);
+    virtual void getCollisionSampling(Real& dx, const Real x_localcurv_abs) = 0;
+    void addCollisionOnBeam(const sofa::Index beam);
     void clearCollisionOnBeam();
 
     virtual void getSamplingParameters(type::vector<Real>& xP_noticeable,
-        type::vector<int>& nbP_density) = 0;
-    virtual void getNumberOfCollisionSegment(Real& dx, unsigned int& numLines) = 0;
+        type::vector<sofa::Size>& nbP_density) = 0;
+    virtual void getNumberOfCollisionSegment(Real& dx, sofa::Size& numLines) = 0;
 
-
-    virtual void getCurvAbsAtBeam(const unsigned int& edgeInList_input, const Real& baryCoord_input, Real& x_output) = 0;
-    virtual void getSplineRestTransform(unsigned int edgeInList, Transform& local_H_local0_rest, Transform& local_H_local1_rest) = 0;
+    virtual void getCurvAbsAtBeam(const EdgeID edgeInList_input, const Real baryCoord_input, Real& x_output) = 0;
+    virtual void getSplineRestTransform(const EdgeID edgeInList, Transform& local_H_local0_rest, Transform& local_H_local1_rest) = 0;
     
     /// Returns the BeamSection @sa m_beamSection corresponding to the given beam
-    virtual const BeamSection& getBeamSection(sofa::Index beamId) = 0;
+    virtual const BeamSection& getBeamSection(const sofa::Index beamId) = 0;
     /// Returns the BeamSection data depending on the beam position at the given beam, similar to @getBeamSection
-    virtual void getInterpolationParameters(sofa::Index beamId, Real& _L, Real& _A, Real& _Iy, Real& _Iz, Real& _Asy, Real& _Asz, Real& J) = 0;
+    virtual void getInterpolationParameters(const sofa::Index beamId, Real& _L, Real& _A, Real& _Iy, Real& _Iz, Real& _Asy, Real& _Asz, Real& J) = 0;
     /// Returns the Young modulus, Poisson's ratio and massDensity coefficient of the section at the given curvilinear abscissa
-    virtual void getMechanicalParameters(sofa::Index beamId, Real& youngModulus, Real& cPoisson, Real& massDensity) = 0;
+    virtual void getMechanicalParameters(const sofa::Index beamId, Real& youngModulus, Real& cPoisson, Real& massDensity) = 0;
 
 
-    virtual void getBeamAtCurvAbs(const Real& x_input, unsigned int& edgeInList_output, Real& baryCoord_output, unsigned int start = 0);
+    virtual void getBeamAtCurvAbs(const Real x_input, sofa::Index& edgeInList_output, Real& baryCoord_output, unsigned int start = 0);
 
     int computeTransform(const EdgeID edgeInList, Transform& global_H_local0, Transform& global_H_local1, const VecCoord& x);
     int computeTransform(const EdgeID edgeInList, const PointID node0Idx, const PointID node1Idx, Transform& global_H_local0, Transform& global_H_local1, const VecCoord& x);
 
-    void getDOFtoLocalTransform(unsigned int edgeInList, Transform& DOF0_H_local0, Transform& DOF1_H_local1);
-    void getDOFtoLocalTransformInGlobalFrame(unsigned int edgeInList, Transform& DOF0Global_H_local0, Transform& DOF1Global_H_local1, const VecCoord& x);
-    void setTransformBetweenDofAndNode(int beam, const Transform& DOF_H_Node, unsigned int zeroORone);
+    void getDOFtoLocalTransform(const EdgeID edgeInList, Transform& DOF0_H_local0, Transform& DOF1_H_local1);
+    void getDOFtoLocalTransformInGlobalFrame(const EdgeID edgeInList, Transform& DOF0Global_H_local0, Transform& DOF1Global_H_local1, const VecCoord& x);
+    void setTransformBetweenDofAndNode(const sofa::Index beam, const Transform& DOF_H_Node, unsigned int zeroORone);
 
-    void getTangent(Vec3& t, const Real& baryCoord,
-        const Transform& global_H_local0, const Transform& global_H_local1, const Real& L);
+    void getTangent(Vec3& t, const Real baryCoord,
+        const Transform& global_H_local0, const Transform& global_H_local1, const Real L);
 
-    int getNodeIndices(unsigned int edgeInList, unsigned int& node0Idx, unsigned int& node1Idx);
+    int getNodeIndices(const EdgeID edgeInList, unsigned int& node0Idx, unsigned int& node1Idx);
 
-    void getSplinePoints(unsigned int edgeInList, const VecCoord& x, Vec3& P0, Vec3& P1, Vec3& P2, Vec3& P3);
+    void getSplinePoints(const EdgeID edgeInList, const VecCoord& x, Vec3& P0, Vec3& P1, Vec3& P2, Vec3& P3);
     unsigned int getStateSize() const;
 
     void computeActualLength(Real& length, const Vec3& P0, const Vec3& P1, const Vec3& P2, const Vec3& P3);
 
-    void computeStrechAndTwist(unsigned int edgeInList, const VecCoord& x, Vec3& ResultNodeO, Vec3& ResultNode1);
+    void computeStrechAndTwist(const EdgeID edgeInList, const VecCoord& x, Vec3& ResultNodeO, Vec3& ResultNode1);
 
 
     
     ///vId_Out provides the id of the multiVecId which stores the position of the Bezier Points
     void updateBezierPoints(const VecCoord& x, sofa::core::VecCoordId& vId_Out);
-    void updateBezierPoints(const VecCoord& x, unsigned int index, VectorVec3& v);
+    void updateBezierPoints(const VecCoord& x, sofa::Index index, VectorVec3& v);
 
 
     /// spline base interpolation of points and transformation
-    void interpolatePointUsingSpline(unsigned int edgeInList, const Real& baryCoord, const Vec3& localPos, const VecCoord& x, Vec3& posResult) {
+    void interpolatePointUsingSpline(const EdgeID edgeInList, const Real baryCoord, const Vec3& localPos, const VecCoord& x, Vec3& posResult) {
         interpolatePointUsingSpline(edgeInList, baryCoord, localPos, x, posResult, true, sofa::core::vec_id::read_access::position);
     }
 
-    void interpolatePointUsingSpline(unsigned int edgeInList, const Real& baryCoord, const Vec3& localPos,
+    void interpolatePointUsingSpline(const EdgeID edgeInList, const Real baryCoord, const Vec3& localPos,
         const VecCoord& x, Vec3& posResult, bool recompute, const sofa::core::ConstVecCoordId& vecXId);
 
 
-    void InterpolateTransformUsingSpline(unsigned int edgeInList, const Real& baryCoord, const Vec3& localPos,
+    void InterpolateTransformUsingSpline(const EdgeID edgeInList, const Real baryCoord, const Vec3& localPos,
         const VecCoord& x, Transform& global_H_localInterpol);
 
-    void InterpolateTransformUsingSpline(Transform& global_H_localResult, const Real& baryCoord,
-        const Transform& global_H_local0, const Transform& global_H_local1, const Real& L);
+    void InterpolateTransformUsingSpline(Transform& global_H_localResult, const Real baryCoord,
+        const Transform& global_H_local0, const Transform& global_H_local1, const Real L);
 
-    void InterpolateTransformAndVelUsingSpline(unsigned int edgeInList, const Real& baryCoord, const Vec3& localPos,
+    void InterpolateTransformAndVelUsingSpline(const EdgeID edgeInList, const Real baryCoord, const Vec3& localPos,
         const VecCoord& x, const VecDeriv& v,
         Transform& global_H_localInterpol, Deriv& v_interpol);
 
 
     /// compute the total bending Rotation Angle while going through the Spline (to estimate the curvature)
-    Real ComputeTotalBendingRotationAngle(const Real& dx_computation, const Transform& global_H_local0,
-        const Transform& global_H_local1, const Real& L,
-        const Real& baryCoordMin, const Real& baryCoordMax);
+    Real ComputeTotalBendingRotationAngle(const Real dx_computation, const Transform& global_H_local0,
+        const Transform& global_H_local1, const Real L,
+        const Real baryCoordMin, const Real baryCoordMax);
 
 
     /// 3DOF mapping
-    void MapForceOnNodeUsingSpline(unsigned int edgeInList, const Real& baryCoord, const Vec3& localPos,
+    void MapForceOnNodeUsingSpline(const EdgeID edgeInList, const Real baryCoord, const Vec3& localPos,
         const VecCoord& x, const Vec3& finput,
         SpatialVector& FNode0output, SpatialVector& FNode1output);
 
     /// 6DoF mapping
-    void MapForceOnNodeUsingSpline(unsigned int edgeInList, const Real& baryCoord, const Vec3& localPos,
+    void MapForceOnNodeUsingSpline(const EdgeID edgeInList, const Real baryCoord, const Vec3& localPos,
         const VecCoord& x, const SpatialVector& f6DofInput,
         SpatialVector& FNode0output, SpatialVector& FNode1output);
 
@@ -212,7 +211,7 @@ public:
     const VecEdges* m_topologyEdges{ nullptr };
 
     ///2. Vector of length of each beam. Same size as @sa d_edgeList
-    Data< type::vector< double > >    d_lengthList;
+    Data< type::vector< Real > >    d_lengthList;
 
     ///3. (optional) apply a rigid Transform between the degree of Freedom and the first node of the beam. Indexation based on the num of Edge
     Data< type::vector< Transform > > d_DOF0TransformNode0;
@@ -224,7 +223,7 @@ public:
     Data< type::vector< Vec2 > >      d_curvAbsList;
 
     ///5. (optional) list of the beams in m_edgeList that need to be considered for collision
-    Data< sofa::type::vector<int> > d_beamCollision;
+    Data< sofa::type::vector<EdgeID> > d_beamCollision;
 
     Data<bool>          d_dofsAndBeamsAligned;
 

--- a/src/BeamAdapter/component/BaseBeamInterpolation.inl
+++ b/src/BeamAdapter/component/BaseBeamInterpolation.inl
@@ -36,7 +36,7 @@ using sofa::core::objectmodel::BaseContext;
 
 template <class DataTypes>
 void BaseBeamInterpolation<DataTypes>::getControlPointsFromFrame(const Transform& global_H_local0, const Transform& global_H_local1,
-    const Real& L,
+    const Real L,
     Vec3& P0, Vec3& P1,
     Vec3& P2, Vec3& P3)
 {
@@ -168,7 +168,7 @@ void BaseBeamInterpolation<DataTypes>::clear()
 
 
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::addBeam(const BaseMeshTopology::EdgeID& eID, const Real& length, const Real& x0, const Real& x1, const Real& angle)
+void BaseBeamInterpolation<DataTypes>::addBeam(const EdgeID eID, const Real length, const Real x0, const Real x1, const Real angle)
 {
     auto edgeList = sofa::helper::getWriteOnlyAccessor(d_edgeList);
     auto lengthList = sofa::helper::getWriteOnlyAccessor(d_lengthList);
@@ -193,14 +193,14 @@ void BaseBeamInterpolation<DataTypes>::addBeam(const BaseMeshTopology::EdgeID& e
 
 
 template <class DataTypes>
-void BaseBeamInterpolation<DataTypes>::getAbsCurvXFromBeam(int beam, Real& x_curv)
+void BaseBeamInterpolation<DataTypes>::getAbsCurvXFromBeam(const sofa::Index beam, Real& x_curv)
 {
     x_curv = d_curvAbsList.getValue()[beam].y();
 }
 
 
 template <class DataTypes>
-void BaseBeamInterpolation<DataTypes>::getAbsCurvXFromBeam(int beam, Real& x_curv_start, Real& x_curv_end)
+void BaseBeamInterpolation<DataTypes>::getAbsCurvXFromBeam(const sofa::Index beam, Real& x_curv_start, Real& x_curv_end)
 {
     Vec2 ca = d_curvAbsList.getValue()[beam];
     x_curv_start = ca.x();
@@ -208,14 +208,14 @@ void BaseBeamInterpolation<DataTypes>::getAbsCurvXFromBeam(int beam, Real& x_cur
 }
 
 template<class DataTypes>
-typename BaseBeamInterpolation<DataTypes>::Real BaseBeamInterpolation<DataTypes>::getLength(unsigned int edgeInList)
+typename BaseBeamInterpolation<DataTypes>::Real BaseBeamInterpolation<DataTypes>::getLength(const EdgeID edgeInList)
 {
     Real _L = d_lengthList.getValue()[edgeInList];
     return _L;
 }
 
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::setLength(unsigned int edgeInList, Real& length)
+void BaseBeamInterpolation<DataTypes>::setLength(const EdgeID edgeInList, Real& length)
 {
     auto lengthList = sofa::helper::getWriteOnlyAccessor(d_lengthList);
     lengthList[edgeInList] = length;
@@ -257,7 +257,7 @@ int BaseBeamInterpolation<DataTypes>::computeTransform(const EdgeID edgeInList,
 
 
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::getBeamAtCurvAbs(const Real& x_input, unsigned int& edgeInList_output, Real& baryCoord_output, unsigned int start)
+void BaseBeamInterpolation<DataTypes>::getBeamAtCurvAbs(const Real x_input, unsigned int& edgeInList_output, Real& baryCoord_output, unsigned int start)
 {
     /// lTotalRest = total length of the
     Real lTotalRest = getRestTotalLength();
@@ -321,7 +321,7 @@ int BaseBeamInterpolation<DataTypes>::computeTransform(const EdgeID edgeInList, 
 
 
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::getDOFtoLocalTransform(unsigned int edgeInList, Transform& DOF0_H_local0, Transform& DOF1_H_local1)
+void BaseBeamInterpolation<DataTypes>::getDOFtoLocalTransform(const EdgeID edgeInList, Transform& DOF0_H_local0, Transform& DOF1_H_local1)
 {
     if (d_dofsAndBeamsAligned.getValue())
     {
@@ -336,7 +336,7 @@ void BaseBeamInterpolation<DataTypes>::getDOFtoLocalTransform(unsigned int edgeI
 
 
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::getDOFtoLocalTransformInGlobalFrame(unsigned int edgeInList, Transform& DOF0Global_H_local0, Transform& DOF1Global_H_local1, const VecCoord& x)
+void BaseBeamInterpolation<DataTypes>::getDOFtoLocalTransformInGlobalFrame(const EdgeID edgeInList, Transform& DOF0Global_H_local0, Transform& DOF1Global_H_local1, const VecCoord& x)
 {
 
     Transform DOF0_H_local0, DOF1_H_local1;
@@ -356,7 +356,7 @@ void BaseBeamInterpolation<DataTypes>::getDOFtoLocalTransformInGlobalFrame(unsig
 
 
 template <class DataTypes>
-void BaseBeamInterpolation<DataTypes>::setTransformBetweenDofAndNode(int beam, const Transform& DOF_H_Node, unsigned int zeroORone)
+void BaseBeamInterpolation<DataTypes>::setTransformBetweenDofAndNode(const sofa::Index beam, const Transform& DOF_H_Node, unsigned int zeroORone)
 {
     if (beam > int(d_DOF0TransformNode0.getValue().size() - 1) || beam > int(d_DOF1TransformNode1.getValue().size() - 1))
     {
@@ -379,9 +379,9 @@ void BaseBeamInterpolation<DataTypes>::setTransformBetweenDofAndNode(int beam, c
 
 ///  getTangent : Computation of a Tangent for the beam (it is given by the derivative of the spline formulation)
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::getTangent(Vec3& t, const Real& baryCoord,
+void BaseBeamInterpolation<DataTypes>::getTangent(Vec3& t, const Real baryCoord,
     const Transform& global_H_local0,
-    const Transform& global_H_local1, const Real& L)
+    const Transform& global_H_local1, const Real L)
 {
     Vec3 P0, P1, P2, P3;
 
@@ -396,7 +396,7 @@ void BaseBeamInterpolation<DataTypes>::getTangent(Vec3& t, const Real& baryCoord
 
 
 template<class DataTypes>
-int BaseBeamInterpolation<DataTypes>::getNodeIndices(unsigned int edgeInList,
+int BaseBeamInterpolation<DataTypes>::getNodeIndices(const EdgeID edgeInList,
     unsigned int& node0Idx,
     unsigned int& node1Idx)
 {
@@ -417,7 +417,7 @@ int BaseBeamInterpolation<DataTypes>::getNodeIndices(unsigned int edgeInList,
 
 
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::getSplinePoints(unsigned int edgeInList, const VecCoord& x, Vec3& P0, Vec3& P1, Vec3& P2, Vec3& P3)
+void BaseBeamInterpolation<DataTypes>::getSplinePoints(const EdgeID edgeInList, const VecCoord& x, Vec3& P0, Vec3& P1, Vec3& P2, Vec3& P3)
 {
     Transform global_H_local0, global_H_local1;
     if (computeTransform(edgeInList, global_H_local0, global_H_local1, x) == -1)
@@ -426,7 +426,7 @@ void BaseBeamInterpolation<DataTypes>::getSplinePoints(unsigned int edgeInList, 
         return;
     }
 
-    const Real& _L = d_lengthList.getValue()[edgeInList];
+    const Real _L = d_lengthList.getValue()[edgeInList];
     this->getControlPointsFromFrame(global_H_local0, global_H_local1, _L, P0, P1, P2, P3);
 
 }
@@ -491,7 +491,7 @@ void BaseBeamInterpolation<DataTypes>::computeActualLength(Real& length, const V
 
 
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::computeStrechAndTwist(unsigned int edgeInList, const VecCoord& x, Vec3& ResultNodeO, Vec3& ResultNode1)
+void BaseBeamInterpolation<DataTypes>::computeStrechAndTwist(const EdgeID edgeInList, const VecCoord& x, Vec3& ResultNodeO, Vec3& ResultNode1)
 {
 
     /// ResultNode = [half length of the beam (m), geometrical Twist angle (rad), additional mechanical Twist angle (rad)]
@@ -596,7 +596,7 @@ template<class DataTypes>
 void BaseBeamInterpolation<DataTypes>::updateBezierPoints(const VecCoord& x, unsigned int index,
     VectorVec3& bezierPosVec) {
     /// <<" interpolatePointUsingSpline : "<< edgeInList<<"  xbary="<<baryCoord<<"  localPos"<<localPos<<std::endl;
-    const Real& _L = d_lengthList.getValue()[index];
+    const Real _L = d_lengthList.getValue()[index];
 
     /// \todo remove call to
     /// nsform2 => make something faster !
@@ -612,8 +612,8 @@ void BaseBeamInterpolation<DataTypes>::updateBezierPoints(const VecCoord& x, uns
 
 
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::interpolatePointUsingSpline(unsigned int edgeInList,
-    const Real& baryCoord,
+void BaseBeamInterpolation<DataTypes>::interpolatePointUsingSpline(const EdgeID edgeInList,
+    const Real baryCoord,
     const Vec3& localPos,
     const VecCoord& x,
     Vec3& posResult,
@@ -623,7 +623,7 @@ void BaseBeamInterpolation<DataTypes>::interpolatePointUsingSpline(unsigned int 
     if (recompute)
     {
         /// <<" interpolatePointUsingSpline : "<< edgeInList<<"  xbary="<<baryCoord<<"  localPos"<<localPos<<std::endl;
-        const Real& _L = d_lengthList.getValue()[edgeInList];
+        const Real _L = d_lengthList.getValue()[edgeInList];
 
         if (localPos.norm() > _L * 1e-10)
         {
@@ -660,7 +660,7 @@ void BaseBeamInterpolation<DataTypes>::interpolatePointUsingSpline(unsigned int 
     else
     {
         /// no need to recompute the positions of the Spline  => we will read their value in the vector which id is vecXId
-        const Real& _L = d_lengthList.getValue()[edgeInList];
+        const Real _L = d_lengthList.getValue()[edgeInList];
 
         if (localPos.norm() > _L * 1e-10)
         {
@@ -698,8 +698,8 @@ void BaseBeamInterpolation<DataTypes>::interpolatePointUsingSpline(unsigned int 
 
 
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::InterpolateTransformUsingSpline(unsigned int edgeInList,
-    const Real& baryCoord,
+void BaseBeamInterpolation<DataTypes>::InterpolateTransformUsingSpline(const EdgeID edgeInList,
+    const Real baryCoord,
     const Vec3& localPos,
     const VecCoord& x,
     Transform& global_H_localInterpol)
@@ -711,7 +711,7 @@ void BaseBeamInterpolation<DataTypes>::InterpolateTransformUsingSpline(unsigned 
         return;
     }
 
-    const Real& _L = d_lengthList.getValue()[edgeInList];
+    const Real _L = d_lengthList.getValue()[edgeInList];
 
     if (localPos.norm() > 1e-10 * _L)
         msg_warning() << "Interpolate frame only on the central curve of the beam. ";
@@ -725,10 +725,10 @@ void BaseBeamInterpolation<DataTypes>::InterpolateTransformUsingSpline(unsigned 
 /// the location of the frame is given by baryCoord
 template<class DataTypes>
 void BaseBeamInterpolation<DataTypes>::InterpolateTransformUsingSpline(Transform& global_H_localResult,
-    const Real& baryCoord,
+    const Real baryCoord,
     const Transform& global_H_local0,
     const Transform& global_H_local1,
-    const Real& L)
+    const Real L)
 {
     Vec3NoInit P0, P1, P2, P3;
 
@@ -787,7 +787,7 @@ void BaseBeamInterpolation<DataTypes>::InterpolateTransformUsingSpline(Transform
 
 
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::InterpolateTransformAndVelUsingSpline(unsigned int edgeInList, const Real& baryCoord,
+void BaseBeamInterpolation<DataTypes>::InterpolateTransformAndVelUsingSpline(const EdgeID edgeInList, const Real baryCoord,
     const Vec3& localPos, const VecCoord& x, const VecDeriv& v,
     Transform& global_H_localInterpol, Deriv& v_interpol)
 {
@@ -813,7 +813,7 @@ void BaseBeamInterpolation<DataTypes>::InterpolateTransformAndVelUsingSpline(uns
 
 
     /// 4. Computes the transformation
-    const Real& _L = d_lengthList.getValue()[edgeInList];
+    const Real _L = d_lengthList.getValue()[edgeInList];
 
     if (localPos.norm() > 1e-10 * _L)
         msg_warning() << "Interpolate frame only on the central curve of the beam";
@@ -853,9 +853,9 @@ void BaseBeamInterpolation<DataTypes>::InterpolateTransformAndVelUsingSpline(uns
 /// Principle: computation of several tangent between node0 to the node1 (given by numComputationPoints)
 /// and computation of an angle (acos) between these successive tangents
 template<class DataTypes>
-typename BaseBeamInterpolation<DataTypes>::Real BaseBeamInterpolation<DataTypes>::ComputeTotalBendingRotationAngle(const Real& dx_computation,
-    const Transform& global_H_local0, const Transform& global_H_local1, const Real& L,
-    const Real& baryCoordMin, const Real& baryCoordMax)
+typename BaseBeamInterpolation<DataTypes>::Real BaseBeamInterpolation<DataTypes>::ComputeTotalBendingRotationAngle(const Real dx_computation,
+    const Transform& global_H_local0, const Transform& global_H_local1, const Real L,
+    const Real baryCoordMin, const Real baryCoordMax)
 {
     Vec3 P0, P1, P2, P3, t0, t1;
 
@@ -897,8 +897,8 @@ typename BaseBeamInterpolation<DataTypes>::Real BaseBeamInterpolation<DataTypes>
 /// Result: Forces (and Torques) on the nodes of this beam
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::MapForceOnNodeUsingSpline(unsigned int edgeInList,
-    const Real& baryCoord, const Vec3& localPos,
+void BaseBeamInterpolation<DataTypes>::MapForceOnNodeUsingSpline(const EdgeID edgeInList,
+    const Real baryCoord, const Vec3& localPos,
     const VecCoord& x, const Vec3& finput,
     SpatialVector& FNode0output, SpatialVector& FNode1output)
 {
@@ -961,7 +961,7 @@ void BaseBeamInterpolation<DataTypes>::MapForceOnNodeUsingSpline(unsigned int ed
 /// Result: Forces (and Torques) on the nodes of this beam
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template<class DataTypes>
-void BaseBeamInterpolation<DataTypes>::MapForceOnNodeUsingSpline(unsigned int edgeInList, const Real& baryCoord,
+void BaseBeamInterpolation<DataTypes>::MapForceOnNodeUsingSpline(const EdgeID edgeInList, const Real baryCoord,
     const Vec3& localPos, const VecCoord& x,
     const SpatialVector& f6DofInput,
     SpatialVector& FNode0output, SpatialVector& FNode1output)

--- a/src/BeamAdapter/component/BeamInterpolation.h
+++ b/src/BeamAdapter/component/BeamInterpolation.h
@@ -88,6 +88,7 @@ public:
 
     using PointID = BaseMeshTopology::PointID;
     using ElementID = BaseMeshTopology::EdgeID;
+    using EdgeID = BaseMeshTopology::EdgeID;
     using VecElementID = type::vector<BaseMeshTopology::EdgeID>;
     using VecEdges = type::vector<BaseMeshTopology::Edge>;    
 
@@ -145,17 +146,17 @@ public:
                                Real &_Asy, Real &_Asz, Real &J) override;
     void getMechanicalParameters(sofa::Index beamId, Real& youngModulus, Real& cPoisson, Real& massDensity) override;
 
-    void getTangentUsingSplinePoints(unsigned int edgeInList, const Real& baryCoord, const sofa::core::ConstVecCoordId &vecXId, Vec3& t );
+    void getTangentUsingSplinePoints(const EdgeID edgeInList, const Real  baryCoord, const sofa::core::ConstVecCoordId &vecXId, Vec3& t );
 
     /// computeActualLength => given the 4 control points of the spline, it provides an estimate of the length (using gauss points integration)
    
-    virtual void getCurvAbsAtBeam(const unsigned int& edgeInList_input, const Real& baryCoord_input, Real& x_output) override
+    virtual void getCurvAbsAtBeam(const EdgeID edgeInList_input, const Real baryCoord_input, Real& x_output) override
     {
         SOFA_UNUSED(edgeInList_input);
         SOFA_UNUSED(baryCoord_input);
         SOFA_UNUSED(x_output);
     }
-    virtual void getBeamAtCurvAbs(const Real& x_input, unsigned int& edgeInList_output, Real& baryCoord_output, unsigned int start = 0) override
+    virtual void getBeamAtCurvAbs(const Real  x_input, unsigned int& edgeInList_output, Real& baryCoord_output, unsigned int start = 0) override
     {
         SOFA_UNUSED(x_input);
         SOFA_UNUSED(edgeInList_output);
@@ -194,15 +195,15 @@ public:
     Data<bool>          d_straight;
 
     virtual void clear() override;
-    virtual void addBeam(const BaseMeshTopology::EdgeID &eID  , const Real &length, const Real &x0, const Real &x1, const Real &angle) override;
+    virtual void addBeam(const EdgeID eID  , const Real length, const Real x0, const Real x1, const Real angle) override;
     virtual void getSamplingParameters(type::vector<Real>& xP_noticeable,
-                                       type::vector<int>& nbP_density) override;
+                                       type::vector<sofa::Size>& nbP_density) override;
     Real getRestTotalLength() override;
-    void getCollisionSampling(Real &dx, const Real& x_localcurv_abs) override;
+    void getCollisionSampling(Real &dx, const Real x_localcurv_abs) override;
     void getNumberOfCollisionSegment(Real &dx, unsigned int &numLines) override;
 
-    void setTransformBetweenDofAndNode(int beam, const Transform &DOF_H_Node, unsigned int zeroORone );
-    void getSplineRestTransform(unsigned int edgeInList, Transform &local_H_local0_rest, Transform &local_H_local1_rest) override;
+    void setTransformBetweenDofAndNode(const sofa::Index beam, const Transform &DOF_H_Node, unsigned int zeroORone );
+    void getSplineRestTransform(const EdgeID edgeInList, Transform &local_H_local0_rest, Transform &local_H_local1_rest) override;
 
     /////////////////////////// Deprecated Methods  ////////////////////////////////////////// 
     [[deprecated("Releasing catheter or brokenIn2 mode is not anymore supported. Feature has been removed after release v23.06")]]
@@ -229,8 +230,8 @@ protected :
 
     void checkDataSize(Real& defaultValue, Data<type::vector<Real>>& dataList, const size_t& nbEdges);
 
-    void computeRectangularCrossSectionInertiaMatrix(const Real &Ly, const Real &Lz, BeamSection &section);
-    void computeCircularCrossSectionInertiaMatrix(const Real &r, const Real &rInner, BeamSection &section);
+    void computeRectangularCrossSectionInertiaMatrix(const Real Ly, const Real Lz, BeamSection &section);
+    void computeCircularCrossSectionInertiaMatrix(const Real r, const Real rInner, BeamSection &section);
 };
 
 #if !defined(SOFA_PLUGIN_BEAMADAPTER_BEAMINTERPOLATION_CPP)

--- a/src/BeamAdapter/component/BeamInterpolation.inl
+++ b/src/BeamAdapter/component/BeamInterpolation.inl
@@ -90,7 +90,7 @@ BeamInterpolation<DataTypes>::BeamInterpolation() :
 }
 
 template <class DataTypes>
-void BeamInterpolation<DataTypes>::computeRectangularCrossSectionInertiaMatrix(const Real& Ly, const Real& Lz, BeamSection& section)
+void BeamInterpolation<DataTypes>::computeRectangularCrossSectionInertiaMatrix(const Real Ly, const Real Lz, BeamSection& section)
 {
     section._Iy=Ly*Lz*Lz*Lz/12.0;
     section._Iz=Lz*Ly*Ly*Ly/12.0;
@@ -102,7 +102,7 @@ void BeamInterpolation<DataTypes>::computeRectangularCrossSectionInertiaMatrix(c
 }
 
 template <class DataTypes>
-void BeamInterpolation<DataTypes>::computeCircularCrossSectionInertiaMatrix(const Real &r, const Real &rInner, BeamSection &section)
+void BeamInterpolation<DataTypes>::computeCircularCrossSectionInertiaMatrix(const Real r, const Real rInner, BeamSection &section)
 {
     section._r = r;
     section._rInner = rInner;
@@ -235,7 +235,7 @@ void BeamInterpolation<DataTypes>::bwdInit()
         auto lengthList = sofa::helper::getWriteOnlyAccessor(this->d_lengthList);
         lengthList.clear();
 
-        const unsigned int edgeListSize = this->d_edgeList.getValue().size();
+        const auto edgeListSize = this->d_edgeList.getValue().size();
         unsigned int nd0Id=0, nd1Id=0;
 
 
@@ -321,7 +321,7 @@ bool BeamInterpolation<DataTypes>::interpolationIsAlreadyInitialized()
     if (this->d_edgeList.getValue().size() == 0)
         return false;
 
-    const unsigned int nbEdges = this->d_edgeList.getValue().size();
+    const auto nbEdges = this->d_edgeList.getValue().size();
 
     if (this->d_DOF0TransformNode0.getValue().size() != nbEdges)
         return false;
@@ -378,7 +378,7 @@ void BeamInterpolation<DataTypes>::clear()
 
 
 template<class DataTypes>
-void BeamInterpolation<DataTypes>::addBeam(const BaseMeshTopology::EdgeID &eID  , const Real &length, const Real &x0, const Real &x1, const Real &angle)
+void BeamInterpolation<DataTypes>::addBeam(const EdgeID eID, const Real length, const Real x0, const Real x1, const Real angle)
 {
     auto edgeList = sofa::helper::getWriteOnlyAccessor(this->d_edgeList);
     auto lengthList = sofa::helper::getWriteOnlyAccessor(this->d_lengthList);
@@ -403,7 +403,7 @@ void BeamInterpolation<DataTypes>::addBeam(const BaseMeshTopology::EdgeID &eID  
 
 
 template <class DataTypes>
-void BeamInterpolation<DataTypes>::getSamplingParameters(type::vector<Real>& /*xP_noticeable*/, type::vector< int>& /*nbP_density*/)
+void BeamInterpolation<DataTypes>::getSamplingParameters(type::vector<Real>& /*xP_noticeable*/, type::vector<sofa::Size>& /*nbP_density*/)
 {
     msg_error()<<"getSamplingParameters is not implemented when _restShape== nullptr : TODO !! ";
 }
@@ -421,7 +421,7 @@ typename BeamInterpolation<DataTypes>::Real BeamInterpolation<DataTypes>::getRes
 }
 
 template <class DataTypes>
-void BeamInterpolation<DataTypes>::getCollisionSampling(Real &dx, const Real& /*x_localcurv_abs*/)
+void BeamInterpolation<DataTypes>::getCollisionSampling(Real &dx, const Real /*x_localcurv_abs*/)
 {
     unsigned int numLines = 30;
     dx = getRestTotalLength()/numLines;
@@ -469,9 +469,9 @@ void BeamInterpolation<DataTypes>::getMechanicalParameters(sofa::Index beamId, R
 
 
 template <class DataTypes>
-void BeamInterpolation<DataTypes>::setTransformBetweenDofAndNode(int beam, const Transform &DOF_H_Node, unsigned int zeroORone )
+void BeamInterpolation<DataTypes>::setTransformBetweenDofAndNode(const sofa::Index beam, const Transform &DOF_H_Node, unsigned int zeroORone)
 {
-    if (beam > int(this->d_DOF0TransformNode0.getValue().size()-1) || beam > int(this->d_DOF1TransformNode1.getValue().size()-1))
+    if (beam > this->d_DOF0TransformNode0.getValue().size()-1 || beam > this->d_DOF1TransformNode1.getValue().size()-1)
     {
         msg_error()<<"WARNING setTransformBetweenDofAndNode on non existing beam";
         return;
@@ -491,7 +491,7 @@ void BeamInterpolation<DataTypes>::setTransformBetweenDofAndNode(int beam, const
 
 
 template<class DataTypes>
-void BeamInterpolation<DataTypes>::getSplineRestTransform(unsigned int edgeInList, Transform &local_H_local0_rest, Transform &local_H_local1_rest)
+void BeamInterpolation<DataTypes>::getSplineRestTransform(const EdgeID edgeInList, Transform &local_H_local0_rest, Transform &local_H_local1_rest)
 {
     if(d_straight.getValue())
     {
@@ -538,7 +538,7 @@ void BeamInterpolation<DataTypes>::getSplineRestTransform(unsigned int edgeInLis
 
 
 template<class DataTypes>
-void BeamInterpolation<DataTypes>::getTangentUsingSplinePoints(unsigned int edgeInList, const Real& baryCoord,
+void BeamInterpolation<DataTypes>::getTangentUsingSplinePoints(const EdgeID edgeInList, const Real baryCoord,
                                                                const sofa::core::ConstVecCoordId &vecXId, Vec3& t )
 {
 
@@ -575,7 +575,7 @@ void BeamInterpolation<DataTypes>::updateInterpolation(){
         dmsg_info() <<"entering updateInterpolation" ;
 
     const type::vector< Vec2 > &interpolationInputs = d_InterpolationInputs.getValue();
-    unsigned int numInterpolatedPositions = interpolationInputs.size();
+    const auto numInterpolatedPositions = interpolationInputs.size();
 
     auto interpolatedPos = sofa::helper::getWriteOnlyAccessor(d_InterpolatedPos);
     auto interpolatedVel = sofa::helper::getWriteOnlyAccessor(d_InterpolatedVel);

--- a/src/BeamAdapter/component/WireBeamInterpolation.h
+++ b/src/BeamAdapter/component/WireBeamInterpolation.h
@@ -91,6 +91,8 @@ public:
     typedef typename Inherited::Vec2 Vec2;
     typedef typename Inherited::Vec3 Vec3;
     typedef typename Inherited::Quat Quat;
+    
+    using EdgeID = BaseMeshTopology::EdgeID;
 
     WireBeamInterpolation(WireRestShape<DataTypes> *_restShape = nullptr);
 
@@ -102,10 +104,10 @@ public:
 
     using BaseBeamInterpolation<DataTypes>::addBeam;
 
-    void addBeam(const BaseMeshTopology::EdgeID &eID  , const Real &length, const Real &x0, const Real &x1,
+    void addBeam(const EdgeID eID, const Real length, const Real x0, const Real x1,
                  const Transform &DOF0_H_Node0, const Transform &DOF1_H_Node1);
 
-    void getSamplingParameters(type::vector<Real>& xP_noticeable, type::vector< int>& nbP_density) override
+    void getSamplingParameters(type::vector<Real>& xP_noticeable, type::vector<sofa::Size>& nbP_density) override
     {
         this->m_restShape->getSamplingParameters(xP_noticeable, nbP_density);
     }
@@ -115,7 +117,7 @@ public:
         return this->m_restShape->getLength();
     }
 
-    void getCollisionSampling(Real &dx, const Real& x_localcurv_abs) override
+    void getCollisionSampling(Real &dx, const Real x_localcurv_abs) override
     {
         this->m_restShape->getCollisionSampling(dx,x_localcurv_abs);
     }
@@ -126,10 +128,10 @@ public:
     }
 
 
-    virtual void getRestTransform(unsigned int edgeInList, Transform &local0_H_local1_rest);
+    virtual void getRestTransform(const EdgeID edgeInList, Transform &local0_H_local1_rest);
     
-    void getCurvAbsAtBeam(const unsigned int& edgeInList_input, const Real& baryCoord_input, Real& x_output) override;
-    void getSplineRestTransform(unsigned int edgeInList, Transform &local_H_local0_rest, Transform &local_H_local1_rest) override;
+    void getCurvAbsAtBeam(const EdgeID edgeInList_input, const Real baryCoord_input, Real& x_output) override;
+    void getSplineRestTransform(const EdgeID edgeInList, Transform &local_H_local0_rest, Transform &local_H_local1_rest) override;
     
     const BeamSection& getBeamSection(sofa::Index beamId) override;
     void getInterpolationParameters(sofa::Index beamId, Real& _L, Real& _A, Real& _Iy, Real& _Iz, Real& _Asy, Real& _Asz, Real& _J) override;
@@ -141,7 +143,7 @@ public:
 
     void setPathToRestShape(const std::string &o){m_restShape.setPath(o);}
 
-    void getRestTransformOnX(Transform &global_H_local, const Real &x)
+    void getRestTransformOnX(Transform &global_H_local, const Real x)
     {
         if(this->m_restShape)
         {
@@ -185,7 +187,7 @@ public:
     /////////////////////////// Deprecated Methods  ////////////////////////////////////////// 
     /// For coils: a part of the coil instrument can be brokenIn2  (by default the point of release is the end of the straight length)
     [[deprecated("Releasing catheter or brokenIn2 mode is not anymore supported. Feature has been removed after release v23.06")]]
-    bool breaksInTwo(const Real& x_min_out, Real& x_break, int& numBeamsNotUnderControlled) {
+    bool breaksInTwo(const Real x_min_out, Real& x_break, int& numBeamsNotUnderControlled) {
         SOFA_UNUSED(x_min_out);
         SOFA_UNUSED(x_break);
         SOFA_UNUSED(numBeamsNotUnderControlled);

--- a/src/BeamAdapter/component/WireBeamInterpolation.inl
+++ b/src/BeamAdapter/component/WireBeamInterpolation.inl
@@ -59,7 +59,7 @@ void WireBeamInterpolation<DataTypes>::init()
     }
 
     type::vector<Real> xP_noticeable;
-    type::vector< int> nbP_density;
+    type::vector<sofa::Size> nbP_density;
 
     m_restShape.get()->getSamplingParameters(xP_noticeable, nbP_density);
 
@@ -81,7 +81,7 @@ template <class DataTypes>
 
 
 template<class DataTypes>
-void WireBeamInterpolation<DataTypes>::addBeam(const BaseMeshTopology::EdgeID &eID  , const Real &length, const Real &x0, const Real &x1,
+void WireBeamInterpolation<DataTypes>::addBeam(const EdgeID eID, const Real length, const Real x0, const Real x1,
                                                const Transform &DOF0_H_Node0, const Transform &DOF1_H_Node1)
 {
     auto edgeList = sofa::helper::getWriteOnlyAccessor(this->d_edgeList);
@@ -104,7 +104,7 @@ void WireBeamInterpolation<DataTypes>::addBeam(const BaseMeshTopology::EdgeID &e
 
 
 template<class DataTypes>
-void WireBeamInterpolation<DataTypes>::getRestTransform(unsigned int edgeInList, Transform &local0_H_local1_rest)
+void WireBeamInterpolation<DataTypes>::getRestTransform(const EdgeID edgeInList, Transform &local0_H_local1_rest)
 {
     msg_warning() << "GetRestTransform not implemented for not straightRestShape" ;
 
@@ -114,7 +114,7 @@ void WireBeamInterpolation<DataTypes>::getRestTransform(unsigned int edgeInList,
 
 
 template<class DataTypes>
-void WireBeamInterpolation<DataTypes>::getSplineRestTransform(unsigned int edgeInList, Transform &local_H_local0_rest, Transform &local_H_local1_rest)
+void WireBeamInterpolation<DataTypes>::getSplineRestTransform(const EdgeID edgeInList, Transform &local_H_local0_rest, Transform &local_H_local1_rest)
 {
     if (this->isControlled() && this->m_restShape!=nullptr)
     {
@@ -147,7 +147,7 @@ void WireBeamInterpolation<DataTypes>::getSplineRestTransform(unsigned int edgeI
 
 
 template<class DataTypes>
-void WireBeamInterpolation<DataTypes>::getCurvAbsAtBeam(const unsigned int &edgeInList_input, const Real& baryCoord_input, Real& x_output)
+void WireBeamInterpolation<DataTypes>::getCurvAbsAtBeam(const EdgeID edgeInList_input, const Real baryCoord_input, Real& x_output)
 {
     ///TODO(dmarchal 2017-05-17): Please tell who and when it will be done.
     // TODO : version plus complete prenant en compte les coupures et autres particularites de ce modele ?
@@ -207,11 +207,11 @@ bool WireBeamInterpolation<DataTypes>::getApproximateCurvAbs(const Vec3& x_input
     Real closestDist = (x_input-globalHlocal0.getOrigin()).norm2();
     Real beamBary = 0.0;
     bool projected = false;
-    unsigned int beamIndex = 0;
+    sofa::Index beamIndex = 0;
 
     // Just look for the closest point on the curve
     // Returns false if this point is not a projection on the curve
-    unsigned int nb = this->getNumBeams();
+    const auto nb = this->getNumBeams();
     for(unsigned int i=0; i<nb; i++)	// Check each segment and each vertex
     {
         this->computeTransform(i, globalHlocal0, globalHlocal1, x);

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -219,7 +219,7 @@ void InterventionalRadiologyController<DataTypes>::bwdInit()
     for (unsigned int i = 0; i < m_instrumentsList.size(); i++)
     {
         type::vector<Real> xP_noticeable_I;
-        type::vector< int > density_I;
+        type::vector<sofa::Size> density_I;
         m_instrumentsList[i]->getSamplingParameters(xP_noticeable_I, density_I);
 
         for (auto nb : density_I)
@@ -467,7 +467,7 @@ void InterventionalRadiologyController<DataTypes>::computeInstrumentsCurvAbs(typ
     for (sofa::Size i=0; i<m_instrumentsList.size(); i++)
     {
         type::vector<Real> xP_noticeable_I;
-        type::vector< int > density_I;
+        type::vector<sofa::Size> density_I;
         m_instrumentsList[i]->getSamplingParameters(xP_noticeable_I, density_I); // sampling of the different section of this instrument
 
         // check each interval of noticeable point to see if they go out (>0) and use corresponding density to sample the interval.

--- a/src/BeamAdapter/component/controller/SutureController.inl
+++ b/src/BeamAdapter/component/controller/SutureController.inl
@@ -121,7 +121,7 @@ void SutureController<DataTypes>::initWireModel()
     }
 
     type::vector< Real > xP_noticeable;
-    type::vector< int > nbP_density;
+    type::vector<sofa::Size> nbP_density;
     l_adaptiveInterpolation->getSamplingParameters(xP_noticeable, nbP_density);
 
     // computation of the number of node on the structure:
@@ -913,7 +913,7 @@ template <class DataTypes>
 void SutureController<DataTypes>::computeSampling(type::vector<Real> &newCurvAbs, VecCoord &x)
 {
     type::vector<Real> xP_noticeable;
-    type::vector<int> nbP_density;
+    type::vector<sofa::Size> nbP_density;
 
     l_adaptiveInterpolation->getSamplingParameters(xP_noticeable, nbP_density);
 

--- a/src/BeamAdapter/component/engine/WireRestShape.h
+++ b/src/BeamAdapter/component/engine/WireRestShape.h
@@ -99,7 +99,7 @@ public:
       * This function provides a type::vector with the curviliar abscissa of the noticeable point(s) 
       * and the minimum density (number of points) between them. (Nb. nbP_density.size() == xP_noticeable.size() - 1)
       */
-     void getSamplingParameters(type::vector<Real>& xP_noticeable, type::vector<int>& nbP_density) const ;
+     void getSamplingParameters(type::vector<Real>& xP_noticeable, type::vector<sofa::Size>& nbP_density) const ;
 
 
      /// Functions enabling to load and use a geometry given from OBJ external file
@@ -134,7 +134,7 @@ protected:
 
 
 public:
-     Data<type::vector<int> > d_density;
+     Data<type::vector<sofa::Size> > d_density;
      Data<type::vector<Real> > d_keyPoints;
      
      /// Vector or links to the Wire section material. The order of the linked material will define the WireShape structure.

--- a/src/BeamAdapter/component/engine/WireRestShape.h
+++ b/src/BeamAdapter/component/engine/WireRestShape.h
@@ -83,16 +83,16 @@ public:
      /////////////////////////// Methods of WireRestShape  //////////////////////////////////////////     
 
      /// This function is called by the force field to evaluate the rest position of each beam
-     void getRestTransformOnX(Transform &global_H_local, const Real &x);
+     void getRestTransformOnX(Transform &global_H_local, const Real x);
 
      /// Returns the BeamSection @sa m_beamSection corresponding to the given curvilinear abscissa, will call @sa BaseRodSectionMaterial::getBeamSection
-     [[nodiscard]] const BeamSection& getBeamSectionAtX(const Real& x_curv) const;
+     [[nodiscard]] const BeamSection& getBeamSectionAtX(const Real x_curv) const;
 
      /// Returns the BeamSection data depending on the beam position at the given curvilinear abscissa, will call @sa BaseRodSectionMaterial::getInterpolationParameters
-     void getInterpolationParametersAtX(const Real& x_curv, Real &_A, Real &_Iy , Real &_Iz, Real &_Asy, Real &_Asz, Real &_J) const;
+     void getInterpolationParametersAtX(const Real x_curv, Real &_A, Real &_Iy , Real &_Iz, Real &_Asy, Real &_Asz, Real &_J) const;
 
      /// Returns the Young modulus, Poisson's ratio and massDensity coefficient of the section at the given curvilinear abscissa, will call @sa BaseRodSectionMaterial::getMechanicalParameters
-     void getMechanicalParametersAtX(const Real& x_curv, Real& youngModulus, Real& cPoisson, Real& massDensity) const;
+     void getMechanicalParametersAtX(const Real x_curv, Real& youngModulus, Real& cPoisson, Real& massDensity) const;
 
 
      /**
@@ -107,8 +107,8 @@ public:
      
      
      Real getLength() ;
-     void getCollisionSampling(Real &dx, const Real &x_curv);
-     void getNumberOfCollisionSegment(Real &dx, unsigned int &numLines) ;
+     void getCollisionSampling(Real &dx, const Real x_curv);
+     void getNumberOfCollisionSegment(Real &dx, sofa::Size& numLines) ;
 
 
 

--- a/src/BeamAdapter/component/engine/WireRestShape.inl
+++ b/src/BeamAdapter/component/engine/WireRestShape.inl
@@ -182,7 +182,7 @@ void WireRestShape<DataTypes>::getSamplingParameters(type::vector<Real>& xP_noti
 
 
 template <class DataTypes>
-void WireRestShape<DataTypes>::getCollisionSampling(Real &dx, const Real &x_curv)
+void WireRestShape<DataTypes>::getCollisionSampling(Real &dx, const Real x_curv)
 {
     unsigned int numLines;
     Real x_used = x_curv - EPSILON;
@@ -229,7 +229,7 @@ void WireRestShape<DataTypes>::getCollisionSampling(Real &dx, const Real &x_curv
 
 
 template <class DataTypes>
-void WireRestShape<DataTypes>::getRestTransformOnX(Transform &global_H_local, const Real &x)
+void WireRestShape<DataTypes>::getRestTransformOnX(Transform &global_H_local, const Real x)
 {
     Real x_used = x - EPSILON;
 
@@ -255,7 +255,7 @@ void WireRestShape<DataTypes>::getRestTransformOnX(Transform &global_H_local, co
 
 
 template <class DataTypes>
-const BeamSection& WireRestShape<DataTypes>::getBeamSectionAtX(const Real& x_curv) const
+const BeamSection& WireRestShape<DataTypes>::getBeamSectionAtX(const Real x_curv) const
 {
     const Real x_used = x_curv - Real(EPSILON);
     const type::vector<Real>& keyPts = d_keyPoints.getValue();
@@ -276,7 +276,7 @@ const BeamSection& WireRestShape<DataTypes>::getBeamSectionAtX(const Real& x_cur
 
 
 template <class DataTypes>
-void WireRestShape<DataTypes>::getInterpolationParametersAtX(const Real& x_curv, Real &_A, Real &_Iy , Real &_Iz, Real &_Asy, Real &_Asz, Real &_J) const
+void WireRestShape<DataTypes>::getInterpolationParametersAtX(const Real x_curv, Real &_A, Real &_Iy , Real &_Iz, Real &_Asy, Real &_Asz, Real &_J) const
 {
     const Real x_used = x_curv - Real(EPSILON);
     const type::vector<Real>& keyPts = d_keyPoints.getValue();
@@ -295,7 +295,7 @@ void WireRestShape<DataTypes>::getInterpolationParametersAtX(const Real& x_curv,
 
 
 template <class DataTypes>
-void WireRestShape<DataTypes>::getMechanicalParametersAtX(const Real& x_curv, Real& youngModulus, Real& cPoisson, Real& massDensity) const
+void WireRestShape<DataTypes>::getMechanicalParametersAtX(const Real x_curv, Real& youngModulus, Real& cPoisson, Real& massDensity) const
 {
     const Real x_used = x_curv - Real(EPSILON);
     const type::vector<Real>& keyPts = d_keyPoints.getValue();
@@ -321,7 +321,7 @@ typename WireRestShape<DataTypes>::Real WireRestShape<DataTypes>::getLength()
 
 
 template <class DataTypes>
-void WireRestShape<DataTypes>::getNumberOfCollisionSegment(Real &dx, unsigned int &numLines)
+void WireRestShape<DataTypes>::getNumberOfCollisionSegment(Real &dx, sofa::Size& numLines)
 {
     numLines = 0;
     for (sofa::Size i = 0; i < l_sectionMaterials.size(); ++i)

--- a/src/BeamAdapter/component/engine/WireRestShape.inl
+++ b/src/BeamAdapter/component/engine/WireRestShape.inl
@@ -174,7 +174,7 @@ bool WireRestShape<DataTypes>::initTopology()
 
 template <class DataTypes>
 void WireRestShape<DataTypes>::getSamplingParameters(type::vector<Real>& xP_noticeable,
-                                                     type::vector<int>& nbP_density) const
+                                                     type::vector<sofa::Size>& nbP_density) const
 {
     xP_noticeable = d_keyPoints.getValue();
     nbP_density = d_density.getValue();

--- a/src/BeamAdapter/component/model/BaseRodSectionMaterial.h
+++ b/src/BeamAdapter/component/model/BaseRodSectionMaterial.h
@@ -72,13 +72,13 @@ public:
     /////////////////////////// Geometry and physics Getter //////////////////////////////////////////
 
     /// Returns the number of visual edges of this section. To be set or computed by child.
-    [[nodiscard]] int getNbVisualEdges() const { return d_nbEdgesVisu.getValue(); }
+    [[nodiscard]] auto getNbVisualEdges() const { return d_nbEdgesVisu.getValue(); }
 
     /// Returns the number of collision edges of this section. To be set or computed by child.
-    [[nodiscard]] int getNbCollisionEdges() const { return d_nbEdgesCollis.getValue(); }
+    [[nodiscard]] auto getNbCollisionEdges() const { return d_nbEdgesCollis.getValue(); }
 
     /// Returns the total length of this section. To be set or computed by child.
-    [[nodiscard]] Real getLength() const { return d_length.getValue(); }
+    [[nodiscard]] auto getLength() const { return d_length.getValue(); }
 
 
     /// Returns the BeamSection @sa m_beamSection corresponding to this section
@@ -91,7 +91,7 @@ public:
     void getMechanicalParameters(Real& youngModulus, Real& cPoisson, Real& massDensity) const;
 
     /// This function is called to get the rest position of the beam depending on the current curved abscisse given in parameter 
-    virtual void getRestTransformOnX(Transform& global_H_local, const Real& x_used, const Real& x_start)
+    virtual void getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start)
     {
         SOFA_UNUSED(global_H_local);
         SOFA_UNUSED(x_used);

--- a/src/BeamAdapter/component/model/RodMeshSection.h
+++ b/src/BeamAdapter/component/model/RodMeshSection.h
@@ -54,7 +54,7 @@ public:
     RodMeshSection();
 
     /// Override method to get the rest position of the beam. In this implementation, it will interpolate along the loaded mesh geometry
-    void getRestTransformOnX(Transform& global_H_local, const Real& x_used, const Real& x_start) override;
+    void getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start) override;
       
 protected:
     /// Internal method to init the section. Called by @sa BaseRodSectionMaterial::init() method

--- a/src/BeamAdapter/component/model/RodMeshSection.inl
+++ b/src/BeamAdapter/component/model/RodMeshSection.inl
@@ -62,7 +62,7 @@ bool RodMeshSection<DataTypes>::initSection()
 
 
 template <class DataTypes>
-void RodMeshSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real& x_used, const Real& x_start)
+void RodMeshSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start)
 {
     Real abs_curr = x_used - x_start;
     abs_curr = abs_curr /(this->d_length.getValue()) * m_absOfGeometry;

--- a/src/BeamAdapter/component/model/RodSpireSection.h
+++ b/src/BeamAdapter/component/model/RodSpireSection.h
@@ -51,7 +51,7 @@ public:
     RodSpireSection();
 
     /// Override method to get the rest position of the beam. In this implementation, it will compute the current position given the spire parameters
-    void getRestTransformOnX(Transform& global_H_local, const Real& x_used, const Real& x_start) override;
+    void getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start) override;
 
 protected:
     /// Internal method to init the section. Called by @sa BaseRodSectionMaterial::init() method

--- a/src/BeamAdapter/component/model/RodSpireSection.inl
+++ b/src/BeamAdapter/component/model/RodSpireSection.inl
@@ -48,25 +48,12 @@ bool RodSpireSection<DataTypes>::initSection()
         return false;
     }
 
-    if (int nbrEdgesVisu = this->d_nbEdgesVisu.getValue() <= 0)
-    {
-        msg_warning() << "Number of visual edges has been set to an invalid value: " << nbrEdgesVisu << ". Value should be a positive integer. Setting to default value: 10";
-        this->d_nbEdgesVisu.setValue(10);
-    }
-
-
-    if (int nbEdgesCollis = this->d_nbEdgesCollis.getValue() <= 0)
-    {
-        msg_warning() << "Number of collision edges has been set to an invalid value: " << nbEdgesCollis << ". Value should be a positive integer. Setting to default value: 20";
-        this->d_nbEdgesCollis.setValue(10);
-    }
-
     return true;
 }
 
 
 template <class DataTypes>
-void RodSpireSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real& x_used, const Real& x_start)
+void RodSpireSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start)
 {
     Real projetedLength = d_spireDiameter.getValue() * M_PI;
     Real lengthSpire = sqrt(d_spireHeight.getValue() * d_spireHeight.getValue() + projetedLength * projetedLength);

--- a/src/BeamAdapter/component/model/RodStraightSection.h
+++ b/src/BeamAdapter/component/model/RodStraightSection.h
@@ -48,7 +48,7 @@ public:
     RodStraightSection();
 
     /// Override method to get the rest position of the beam. In this implementation, it will basically returns Vec3(x_start + x_used, 0 0)
-    void getRestTransformOnX(Transform& global_H_local, const Real& x_used, const Real& x_start) override;
+    void getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start) override;
 
 protected:
     /// Internal method to init the section. Called by @sa BaseRodSectionMaterial::init() method

--- a/src/BeamAdapter/component/model/RodStraightSection.inl
+++ b/src/BeamAdapter/component/model/RodStraightSection.inl
@@ -46,25 +46,12 @@ bool RodStraightSection<DataTypes>::initSection()
         return false;
     }
 
-    if (int nbrEdgesVisu = this->d_nbEdgesVisu.getValue() <= 0)
-    {
-        msg_warning() << "Number of visual edges has been set to an invalid value: " << nbrEdgesVisu << ". Value should be a positive integer. Setting to default value: 10";
-        this->d_nbEdgesVisu.setValue(10);
-    }
-
-
-    if (int nbEdgesCollis = this->d_nbEdgesCollis.getValue() <= 0)
-    {
-        msg_warning() << "Number of collision edges has been set to an invalid value: " << nbEdgesCollis << ". Value should be a positive integer. Setting to default value: 20";
-        this->d_nbEdgesCollis.setValue(10);
-    }
-
     return true;
 }
 
 
 template <class DataTypes>
-void RodStraightSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real& x_used, const Real& x_start)
+void RodStraightSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start)
 {
     global_H_local.set(type::Vec3(x_start + x_used, 0.0, 0.0), Quat());
 }


### PR DESCRIPTION
Cleaning (a bit) the cesspool 🥴 in the interpolation/shape part

- remove all the const ref for simple types
- use more sane types for IDs/size (and use aliases for clearer intent)
- add some const for more clarity for inputs/outputs

Breaking as it changes a lot of method signatures
