### PR TITLE
[Wire Shape] Fix the confusion between the nbEdgesCollision and the number of mechanical Beams

### DIFF
--- a/src/BeamAdapter/component/BaseBeamInterpolation.h
+++ b/src/BeamAdapter/component/BaseBeamInterpolation.h
@@ -114,6 +114,8 @@ public:
     Real getLength(const EdgeID edgeInList);
     void setLength(const EdgeID edgeInList, Real& length);
     
+    virtual void getMechanicalSampling(Real& dx, const Real x_localcurv_abs) = 0;
+    
     /// Collision information using @sa d_beamCollision
     virtual void getCollisionSampling(Real& dx, const Real x_localcurv_abs) = 0;
     void addCollisionOnBeam(const sofa::Index beam);

--- a/src/BeamAdapter/component/BeamInterpolation.h
+++ b/src/BeamAdapter/component/BeamInterpolation.h
@@ -199,6 +199,7 @@ public:
     virtual void getSamplingParameters(type::vector<Real>& xP_noticeable,
                                        type::vector<sofa::Size>& nbP_density) override;
     Real getRestTotalLength() override;
+    void getMechanicalSampling(Real& dx, const Real x_localcurv_abs) override;
     void getCollisionSampling(Real &dx, const Real x_localcurv_abs) override;
     void getNumberOfCollisionSegment(Real &dx, unsigned int &numLines) override;
 

--- a/src/BeamAdapter/component/BeamInterpolation.inl
+++ b/src/BeamAdapter/component/BeamInterpolation.inl
@@ -420,17 +420,29 @@ typename BeamInterpolation<DataTypes>::Real BeamInterpolation<DataTypes>::getRes
     return le;
 }
 
+
 template <class DataTypes>
-void BeamInterpolation<DataTypes>::getCollisionSampling(Real &dx, const Real /*x_localcurv_abs*/)
+void BeamInterpolation<DataTypes>::getMechanicalSampling(Real& dx, const Real x_localcurv_abs)
 {
-    unsigned int numLines = 30;
+    SOFA_UNUSED(x_localcurv_abs);
+    
+    const auto numLines = this->m_topologyEdges->size();
+    dx = getRestTotalLength()/numLines;
+}
+
+template <class DataTypes>
+void BeamInterpolation<DataTypes>::getCollisionSampling(Real &dx, const Real x_localcurv_abs)
+{
+    SOFA_UNUSED(x_localcurv_abs);
+    
+    const auto numLines = this->m_topologyEdges->size();
     dx = getRestTotalLength()/numLines;
 }
 
 template <class DataTypes>
 void BeamInterpolation<DataTypes>::getNumberOfCollisionSegment(Real &dx, unsigned int &numLines)
 {
-    numLines = 30;
+    numLines = static_cast<unsigned int>(this->m_topologyEdges->size());
     dx = getRestTotalLength()/numLines;
 }
 

--- a/src/BeamAdapter/component/WireBeamInterpolation.h
+++ b/src/BeamAdapter/component/WireBeamInterpolation.h
@@ -117,6 +117,11 @@ public:
         return this->m_restShape->getLength();
     }
 
+    void getMechanicalSampling(Real &dx, const Real x_localcurv_abs) override
+    {
+        this->m_restShape->getMechanicalSampling(dx,x_localcurv_abs);
+    }
+    
     void getCollisionSampling(Real &dx, const Real x_localcurv_abs) override
     {
         this->m_restShape->getCollisionSampling(dx,x_localcurv_abs);

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.h
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.h
@@ -180,6 +180,10 @@ public:
     SingleLink<
         InterventionalRadiologyController, FixedProjectiveConstraint<DataTypes>,
         BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_fixedConstraint;
+    SingleLink<
+        InterventionalRadiologyController, sofa::core::topology::BaseMeshTopology,
+        BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_mechanicalTopology;
+    
     DeprecatedAndRemoved m_fixedConstraint;
 
     type::vector<Vec3d>                   m_sensorMotionData;

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -567,7 +567,7 @@ void InterventionalRadiologyController<DataTypes>::interventionalRadiologyCollis
     for (int i = static_cast<int>(xPointList.size()) - 1; i>=0; i--)
     {
         //1.  we determin if the poin ument
-        int instrumentId = idInstrumentList[i];
+        const int instrumentId = idInstrumentList[i];
 
         // x_max for the instrument that is controlled (not dropped part)
         Real xMaxControlled = m_instrumentsList[instrumentId]->getRestTotalLength();
@@ -585,9 +585,9 @@ void InterventionalRadiologyController<DataTypes>::interventionalRadiologyCollis
         xPointList[i] = xAbsCurv - xBegin; // provides the "local" curv absc of the point (on the instrument reference)
         idInstrumentList[i] = firstInstruOnx;
 
-        // 3. we look for the collision sampling of the current instrument in order to "place" the following point
+        // 3. we look for the mechanical sampling of the current instrument in order to "place" the following point
         Real xIncr;
-        m_instrumentsList[firstInstruOnx]->getCollisionSampling(xIncr, xPointList[i]);
+        m_instrumentsList[firstInstruOnx]->getMechanicalSampling(xIncr, xPointList[i]);
         xAbsCurv -= xIncr;
 
         // the following point could not have x_abs_curv<0;
@@ -626,7 +626,7 @@ void InterventionalRadiologyController<DataTypes>::interventionalRadiologyCollis
 
     for (unsigned int i=0; i<xPointList.size(); i++)
     {
-        int instrumentId = idInstrumentList[i];
+        const int instrumentId = idInstrumentList[i];
 
         // x_max for the instrument that is controlled (not dropped part)
         Real xMaxInstrument = m_instrumentsList[instrumentId]->getRestTotalLength();
@@ -709,7 +709,7 @@ void InterventionalRadiologyController<DataTypes>::applyInterventionalRadiologyC
 
     // Create vectors with the CurvAbs of the noticiable points and the id of the corresponding instrument
     type::vector<Real> newCurvAbs;
-    type::vector<type::vector<int>> idInstrumentTable;
+    type::vector<type::vector<int>> idInstrumentTable; // i.e for each node -> [instID0, instID1...]
 
     // ## STEP 1: Find the total length of the COMBINED INSTRUMENTS and the one for which xtip > 0 (so the one which are simulated)
     helper::AdvancedTimer::stepBegin("step1");
@@ -767,10 +767,11 @@ void InterventionalRadiologyController<DataTypes>::applyInterventionalRadiologyC
     //    => Get write access to current nodes/dofs
     Data<VecCoord>* datax = this->getMechanicalState()->write(sofa::core::vec_id::write_access::position);
     auto x = sofa::helper::getWriteOnlyAccessor(*datax);
-    VecCoord xbuf = x.ref();
+    const VecCoord xbuf = x.ref(); // make a copy of the positions, as it will changed meanwhile
     
     const sofa::Size numberOfNodes = x.size();
     sofa::Size numberOfSimulatedNodes = newCurvAbs.size(); // number of simulated nodes
+
     if (numberOfSimulatedNodes > numberOfNodes)
     {
         msg_warning() << "Parameters missmatch. There are more curv abscisses '" << numberOfSimulatedNodes << "' than the number of dof: " << numberOfNodes;
@@ -1012,7 +1013,7 @@ void InterventionalRadiologyController<DataTypes>::fillInstrumentCurvAbsTable(co
         xBegin -= threshold;
         xEnd += threshold;
 
-        // check curvAbs sorted value, if value is inside [xBegin, xBegin] of the tool add it to instrumentList. 
+        // check curvAbs sorted value, if value is inside [xBegin, xEnd] of the tool add it to instrumentList.
         for (unsigned int i = 0; i < curvAbs.size(); i++)
         {
             if (curvAbs[i] < xBegin) // still not inside range

--- a/src/BeamAdapter/component/engine/WireRestShape.h
+++ b/src/BeamAdapter/component/engine/WireRestShape.h
@@ -107,10 +107,10 @@ public:
      
      
      Real getLength() ;
-     void getCollisionSampling(Real &dx, const Real x_curv);
-     void getNumberOfCollisionSegment(Real &dx, sofa::Size& numLines) ;
-
-
+    
+    void getMechanicalSampling(Real& dx, const Real x_localcurv_abs);
+    void getCollisionSampling(Real &dx, const Real x_curv);
+    void getNumberOfCollisionSegment(Real &dx, sofa::Size& numLines);
 
      /////////////////////////// Deprecated Methods  ////////////////////////////////////////// 
 
@@ -142,9 +142,7 @@ public:
 
 private:
      /// Link to be set to the topology container in the component graph.
-     SingleLink<WireRestShape<DataTypes>, TopologyContainer, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;     
-     /// Pointer to the topology container, should be set using @sa l_topology, otherwise will search for one in current Node.
-     TopologyContainer* _topology{ nullptr }; 
+     SingleLink<WireRestShape<DataTypes>, sofa::core::topology::BaseMeshTopology, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_topology;
 };
 
 

--- a/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
+++ b/src/BeamAdapter/component/forcefield/AdaptiveBeamForceFieldAndMass.inl
@@ -60,7 +60,7 @@ AdaptiveBeamForceFieldAndMass<DataTypes>::AdaptiveBeamForceFieldAndMass()
     , m_defaultMassDensity(Real(1.))
     , d_massDensity(initData(&d_massDensity,type::vector<Real>(1, m_defaultMassDensity),"massDensity", "Density of the mass" ))
     , d_useShearStressComputation(initData(&d_useShearStressComputation, true, "shearStressComputation","if false, suppress the shear stress in the computation"))
-    , d_reinforceLength(initData(&d_reinforceLength, false, "reinforceLength", "if true, a separate computation for the error in elongation is peformed"))
+    , d_reinforceLength(initData(&d_reinforceLength, false, "reinforceLength", "if true, a separate computation for the error in elongation is performed"))
     , l_interpolation(initLink("interpolation","Path to the Interpolation component on scene"))
 
 {
@@ -507,7 +507,7 @@ void AdaptiveBeamForceFieldAndMass<DataTypes>::addForce (const MechanicalParams*
     ///* Calculer les rotation et les transformations
     ///* Calculer la matrice "locale"
     ///* Calculer la force exercée par chaque beam
-    ///* Calculer la force exercée par la gravitée
+    ///* Calculer la force exercée par la gravité
     for (sofa::Index beamId=0; beamId <numBeams; beamId++)
     {
         ///find the indices of the nodes

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
@@ -384,7 +384,7 @@ int MultiAdaptiveBeamMapping< TIn, TOut>::addBaryPoint(const int& edgeId,const V
     int nbUnControlledEdges = totalNbEdges - nbControlledEdge;
     assert(nbUnControlledEdges>=0);
 
-    if (edgeId < (totalNbEdges-nbControlledEdge) )
+    if (edgeId < nbUnControlledEdges )
     {
         //if the edge in question is not under control, dont need to compute for collision
     }

--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
@@ -213,7 +213,7 @@ void MultiAdaptiveBeamMapping< TIn, TOut>::assignSubMappingFromControllerInfo()
             }
             else
             {
-                msg_error() << "Trying to remove baseEdge which is alreay empty. This case is not supposed to happened.";
+                msg_error() << "Trying to remove baseEdge which is already empty. This case is not supposed to happened.";
             }
 
             if (edgeToRemove.size()>0)
@@ -308,7 +308,7 @@ void MultiAdaptiveBeamMapping< TIn, TOut>::init()
     unsigned int numSeg, numLinesInstrument;
     numSeg=0;
     InReal DX=0;
-    // we chose the collision parameters of the most discrestized instrument
+    // we chose the collision parameters of the most discretized instrument
     for (unsigned int i=0; i<m_instrumentList.size(); i++)
     {
         InReal dx=0;

--- a/src/BeamAdapter/component/model/BaseRodSectionMaterial.h
+++ b/src/BeamAdapter/component/model/BaseRodSectionMaterial.h
@@ -43,7 +43,7 @@ using sofa::core::loader::MeshLoader;
  * Method @sa initSection and @sa getRestTransformOnX should be overriden to provide the correct creation and interpolation.
  * 
  * The rod section is described by:
- * - Topology parameters: vertices and edges @sa d_nbEdgesVisu and @sa d_nbEdgesCollis
+ * - Topology parameters: vertices and edges @sa d_nbEdgesVisu, @sa d_nbEdgesCollis and @sa d_nbBeams
  * - Geometry parameters: radius @sa d_radius, @sa d_innerRadius and length @sa d_length
  * - Mechanical parameters: @sa d_poissonRatio and @sa d_youngModulus
  */
@@ -76,6 +76,9 @@ public:
 
     /// Returns the number of collision edges of this section. To be set or computed by child.
     [[nodiscard]] auto getNbCollisionEdges() const { return d_nbEdgesCollis.getValue(); }
+    
+    /// Returns the number of collision edges of this section. To be set or computed by child.
+    [[nodiscard]] auto getNbBeams() const { return d_nbBeams.getValue(); }
 
     /// Returns the total length of this section. To be set or computed by child.
     [[nodiscard]] auto getLength() const { return d_length.getValue(); }
@@ -111,6 +114,7 @@ public:
     Data<Real> d_innerRadius; ///< Data defining the geometry internal radius of this section is hollow 
     Data<Real> d_length; ///< Data defining the geometry length of this section
 
+    Data<Size> d_nbBeams; ///< Data defining the number of (mechanical) beams composing this section
     Data<Size> d_nbEdgesVisu; ///< Data defining the number of visual edges composing this section
     Data<Size> d_nbEdgesCollis; ///< Data defining the number of collision edges composing this section
 

--- a/src/BeamAdapter/component/model/BaseRodSectionMaterial.inl
+++ b/src/BeamAdapter/component/model/BaseRodSectionMaterial.inl
@@ -34,8 +34,9 @@ BaseRodSectionMaterial<DataTypes>::BaseRodSectionMaterial()
     , d_radius(initData(&d_radius, (Real)1.0, "radius", "Full radius of this section"))
     , d_innerRadius(initData(&d_innerRadius, (Real)0.0, "innerRadius", "Inner radius of this section if hollow"))   
     , d_length(initData(&d_length, (Real)1.0, "length", "Total length of this section"))
-    , d_nbEdgesVisu(initData(&d_nbEdgesVisu, (Size)10, "nbEdgesVisu", "number of Edges for the visual model"))
-    , d_nbEdgesCollis(initData(&d_nbEdgesCollis, (Size)20, "nbEdgesCollis", "number of Edges for the collision model"))
+    , d_nbBeams(initData(&d_nbBeams, (Size)5, "nbBeams", "Number of Beams for the mechanical model"))
+    , d_nbEdgesVisu(initData(&d_nbEdgesVisu, (Size)10, "nbEdgesVisu", "Number of Edges for the visual model"))
+    , d_nbEdgesCollis(initData(&d_nbEdgesCollis, (Size)20, "nbEdgesCollis", "Number of Edges for the collision model"))
 {
 
 }

--- a/src/BeamAdapter/component/model/BaseRodSectionMaterial.inl
+++ b/src/BeamAdapter/component/model/BaseRodSectionMaterial.inl
@@ -47,6 +47,12 @@ void BaseRodSectionMaterial<DataTypes>::init()
 {
     this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Loading);
 
+    if(!d_nbBeams.isSet())
+    {
+        msg_deprecated() << "nbBeams is now required but it was not set. Its value will be copied from nbEdgesCollis as a temporary compatibility solution.";
+        d_nbBeams.setValue(d_nbEdgesCollis.getValue());
+    }
+    
     // Prepare beam sections
     double r = this->d_radius.getValue();
     double rInner = this->d_innerRadius.getValue();


### PR DESCRIPTION
In a nutshell, there is a confusion in the description of a tool, where nbEdgesCollision set the number of mechanical beams...
So in the end the number of beams will be the same as the number of collision edges. 
It is especially problematic where you want a certain part of your tool to be more "collidable" but it does not necessarily need more "beams".

There is a little compat part if a user did not specify "nbBeams", it will take the value of nbEdgesCollision (like it is now)