### PR TITLE
[Scenes] Fix runtime warnings, and consistent behavior between python and xml

### DIFF
--- a/examples/3instruments.scn
+++ b/examples/3instruments.scn
@@ -19,11 +19,11 @@
  	<DefaultVisualManagerLoop/>
 
 
-<!-- ------------------------- INTERVENTIONAL RADIOLOGY INSTRUMENTS (catheter, guidewire, coil)  ------------------------------ -->
+<!-- INTERVENTIONAL RADIOLOGY INSTRUMENTS (catheter, guidewire, coil)  -->
 
 	<Node name='topoLines_cath'> 
-        <RodStraightSection name="StraightSection" youngModulus="10000" massDensity='0.00000155' nbEdgesCollis="40" nbEdgesVisu="120" length="600.0" radius='1'/> <!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->	
-        <RodSpireSection name="SpireSection" youngModulus="10000" massDensity='0.00000155' nbEdgesCollis="20" nbEdgesVisu="80" length="400.0" spireDiameter="4000.0" spireHeight="0.0" radius='1'/>
+        <RodStraightSection name="StraightSection" youngModulus="10000" massDensity='0.00000155' nbBeams="40" nbEdgesCollis="40" nbEdgesVisu="120" length="600.0" radius='1'/> <!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->	
+        <RodSpireSection name="SpireSection" youngModulus="10000" massDensity='0.00000155' nbBeams="20" nbEdgesCollis="20" nbEdgesVisu="80" length="400.0" spireDiameter="4000.0" spireHeight="0.0" radius='1'/>
         
         <WireRestShape template="Rigid3d" name="catheterRestShape" wireMaterials="@StraightSection @SpireSection"/>
     
@@ -33,8 +33,8 @@
 		<MechanicalObject template='Rigid3d' name='dofTopo1' />
 	</Node>
 	<Node name='topoLines_guide'>
-        <RodStraightSection name="StraightSection" youngModulus="10000" massDensity='0.00000155' nbEdgesCollis="50" nbEdgesVisu="196" length="980.0" radius='0.9'/> <!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->
-        <RodSpireSection name="SpireSection" youngModulus="10000" massDensity='0.00000155' nbEdgesCollis="10" nbEdgesVisu="4" length="20.0" spireDiameter="25" spireHeight="0.0" radius='0.9'/>
+        <RodStraightSection name="StraightSection" youngModulus="10000" massDensity='0.00000155' nbBeams="50" nbEdgesCollis="50" nbEdgesVisu="196" length="980.0" radius='0.9'/> <!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->
+        <RodSpireSection name="SpireSection" youngModulus="10000" massDensity='0.00000155' nbBeams="10" nbEdgesCollis="10" nbEdgesVisu="4" length="20.0" spireDiameter="25" spireHeight="0.0" radius='0.9'/>
 		
         <WireRestShape template="Rigid3d" name="GuideRestShape" wireMaterials="@StraightSection @SpireSection"/>
         
@@ -44,8 +44,8 @@
 		<MechanicalObject template='Rigid3d' name='dofTopo2' />
 	</Node>
 	<Node name='topoLines_coils'>
-        <RodStraightSection name="StraightSection" youngModulus="168000" massDensity='0.000021' nbEdgesCollis="30" nbEdgesVisu="360" length="540.0" radius='0.1'/> <!-- platine E = 168000 MPa // 21000 Kg/m3-->	
-        <RodSpireSection name="SpireSection" youngModulus="168000" massDensity='0.000021' nbEdgesCollis="30" nbEdgesVisu="40" length="60.0" spireDiameter="7" spireHeight="5.0" radius='0.1'/>
+        <RodStraightSection name="StraightSection" youngModulus="168000" massDensity='0.000021' nbBeams="30" nbEdgesCollis="30" nbEdgesVisu="360" length="540.0" radius='0.1'/> <!-- platine E = 168000 MPa // 21000 Kg/m3-->	
+        <RodSpireSection name="SpireSection" youngModulus="168000" massDensity='0.000021' nbBeams="30" nbEdgesCollis="30" nbEdgesVisu="40" length="60.0" spireDiameter="7" spireHeight="5.0" radius='0.1'/>
 		
         <WireRestShape template="Rigid3d" name="CoilRestShape" wireMaterials="@StraightSection @SpireSection"/>
     
@@ -60,7 +60,7 @@
 		<EulerImplicitSolver rayleighStiffness='0.2' rayleighMass='0.1' printLog='false' />
 		<BTDLinearSolver subpartSolve='0' verification='0' verbose='0'/>
 		<RegularGridTopology name='meshLinesCombined'
-            nx='180' ny='1' nz='1'
+            nx='181' ny='1' nz='1'
             xmin='0.0' xmax='1.0'
             ymin='0' ymax='0'
             zmin='1' zmax='1'

--- a/examples/3instruments_collis.scn
+++ b/examples/3instruments_collis.scn
@@ -76,7 +76,7 @@
 		<EulerImplicitSolver rayleighStiffness="0.2" rayleighMass="0.1" printLog="false" />
 		<BTDLinearSolver subpartSolve="0" verification="0" verbose="0"/>
 		<RegularGridTopology name="meshLinesCombined"
-            nx="181" ny="1" nz="1"
+            nx="180" ny="1" nz="1"
             xmin="0.0" xmax="1.0"
             ymin="0" ymax="0"
             zmin="1" zmax="1"

--- a/examples/3instruments_collis.scn
+++ b/examples/3instruments_collis.scn
@@ -35,7 +35,7 @@
 	<LocalMinDistance name="localmindistance" alarmDistance="2" contactDistance="1" angleCone="0.5" coneFactor="0.5" />
 	<CollisionResponse name="Response" response="FrictionContactConstraint" />
 
-<!-- ------------------------- INTERVENTIONAL RADIOLOGY INSTRUMENTS (catheter, guidewire, coil)  ------------------------------ -->
+<!-- INTERVENTIONAL RADIOLOGY INSTRUMENTS (catheter, guidewire, coil)  -->
 
 	<Node name="topoLines_cath">
         <RodStraightSection name="StraightSection" youngModulus="10000" massDensity="0.00000155" radius="1" nbEdgesCollis="40" nbEdgesVisu="220" length="600.0"/><!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->	
@@ -142,14 +142,21 @@
 		</Node>   
 	</Node>
 
-	<Node name="CollisionModel"> 
-		<MeshOBJLoader name="meshLoader" filename="mesh/phantom.obj" triangulate="true" flipNormals="1"/>
-		<MeshTopology position="@meshLoader.position"  triangles="@meshLoader.triangles"/>
-		<MechanicalObject name="DOFs1" position="0 0 400" scale="3" ry="90"/>	
-		<TriangleCollisionModel simulated="0" moving="0"/>	
-		<LineCollisionModel simulated="0" moving="0"/>
-		<PointCollisionModel simulated="0" moving="0"/>
-		<OglModel name="Visual" src="@meshLoader" color="1 0 0 0.3" scale="3" ry="90"/>
+	<Node name="VesselsPhantom">
+		<MeshOBJLoader name="meshLoader" filename="mesh/phantom.obj" triangulate="true" flipNormals="1" scale="3" rotation="0 90 0"/>
+
+		<Node name="Collision"> 
+			<MeshTopology position="@../meshLoader.position"  triangles="@meshLoader.triangles"/>
+			<MechanicalObject name="DOFs1"/>	
+			<TriangleCollisionModel simulated="0" moving="0"/>	
+			<LineCollisionModel simulated="0" moving="0"/>
+			<PointCollisionModel simulated="0" moving="0"/>
+		</Node>
+
+		<Node name="Visual">
+			<OglModel name="Visual" src="@../meshLoader" color="1 0 0 0.3" />
+		</Node> 
+
 	</Node>
 	
 </Node>

--- a/examples/3instruments_collis.scn
+++ b/examples/3instruments_collis.scn
@@ -38,8 +38,8 @@
 <!-- INTERVENTIONAL RADIOLOGY INSTRUMENTS (catheter, guidewire, coil)  -->
 
 	<Node name="topoLines_cath">
-        <RodStraightSection name="StraightSection" youngModulus="10000" massDensity="0.00000155" radius="1" nbEdgesCollis="40" nbEdgesVisu="220" length="600.0"/><!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->	
-        <RodSpireSection name="SpireSection" youngModulus="10000" massDensity="0.00000155" radius="1" nbEdgesCollis="10" nbEdgesVisu="80" length="400.0" spireDiameter="4000.0" spireHeight="0.0"/>        
+        <RodStraightSection name="StraightSection" youngModulus="10000" massDensity="0.00000155" radius="1" nbBeams="40" nbEdgesCollis="40" nbEdgesVisu="220" length="600.0"/><!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->	
+        <RodSpireSection name="SpireSection" youngModulus="10000" massDensity="0.00000155" radius="1" nbBeams="10" nbEdgesCollis="10" nbEdgesVisu="80" length="400.0" spireDiameter="4000.0" spireHeight="0.0"/>        
         
         <WireRestShape template="Rigid3d" name="catheterRestShape" wireMaterials="@StraightSection @SpireSection"/> <!-- silicone -->		
     
@@ -49,8 +49,8 @@
 		<MechanicalObject template="Rigid3d" name="dofTopo1" />
 	</Node>
 	<Node name="topoLines_guide">
-        <RodStraightSection name="StraightSection" youngModulus="10000" massDensity="0.00000155" radius="0.9" nbEdgesCollis="50" nbEdgesVisu="196" length="980.0"/> <!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->	
-        <RodSpireSection name="SpireSection" youngModulus="10000" massDensity="0.00000155" radius="0.9" nbEdgesCollis="10" nbEdgesVisu="4" length="20.0" spireDiameter="25" spireHeight="0.0"/>        
+        <RodStraightSection name="StraightSection" youngModulus="10000" massDensity="0.00000155" radius="0.9" nbBeams="50" nbEdgesCollis="50" nbEdgesVisu="196" length="980.0"/> <!--stiff silicone E = 10000 MPa // 1550 Kg/m3-->	
+        <RodSpireSection name="SpireSection" youngModulus="10000" massDensity="0.00000155" radius="0.9" nbBeams="10" nbEdgesCollis="10" nbEdgesVisu="4" length="20.0" spireDiameter="25" spireHeight="0.0"/>        
 		
         <WireRestShape template="Rigid3d" name="GuideRestShape" wireMaterials="@StraightSection @SpireSection"/>
     
@@ -60,8 +60,8 @@
 		<MechanicalObject template="Rigid3d" name="dofTopo2" />
 	</Node>
 	<Node name="topoLines_coils">
-        <RodStraightSection name="StraightSection" youngModulus="168000" massDensity="0.000021" radius="0.1" nbEdgesCollis="30" nbEdgesVisu="360" length="540.0"/> <!-- platine E = 168000 MPa // 21000 Kg/m3-->
-        <RodSpireSection name="SpireSection" youngModulus="168000" massDensity="0.000021" radius="0.1" nbEdgesCollis="30" nbEdgesVisu="40" length="60.0" spireDiameter="7" spireHeight="5.0"/>        
+        <RodStraightSection name="StraightSection" youngModulus="168000" massDensity="0.000021" radius="0.1" nbBeams="30" nbEdgesCollis="30" nbEdgesVisu="360" length="540.0"/> <!-- platine E = 168000 MPa // 21000 Kg/m3-->
+        <RodSpireSection name="SpireSection" youngModulus="168000" massDensity="0.000021" radius="0.1" nbBeams="30" nbEdgesCollis="30" nbEdgesVisu="40" length="60.0" spireDiameter="7" spireHeight="5.0"/>        
 		
         <WireRestShape template="Rigid3d" name="CoilRestShape" wireMaterials="@StraightSection @SpireSection"/>
         
@@ -76,7 +76,7 @@
 		<EulerImplicitSolver rayleighStiffness="0.2" rayleighMass="0.1" printLog="false" />
 		<BTDLinearSolver subpartSolve="0" verification="0" verbose="0"/>
 		<RegularGridTopology name="meshLinesCombined"
-            nx="180" ny="1" nz="1"
+            nx="181" ny="1" nz="1"
             xmin="0.0" xmax="1.0"
             ymin="0" ymax="0"
             zmin="1" zmax="1"

--- a/examples/SingleBeamDeployment.scn
+++ b/examples/SingleBeamDeployment.scn
@@ -15,8 +15,8 @@
     <DefaultVisualManagerLoop />
 
     <Node name="EdgeTopology">
-        <RodStraightSection name="StraightSection" youngModulus="20000" radius="0.9" massDensity="0.00000155" nbEdgesCollis="30" nbEdgesVisu="196" length="980.0"/>
-        <RodSpireSection name="SpireSection" youngModulus="20000" radius="0.9" massDensity="0.00000155" nbEdgesCollis="5" nbEdgesVisu="4" length="20.0" spireDiameter="25" spireHeight="0.0"/>
+        <RodStraightSection name="StraightSection" youngModulus="20000" radius="0.9" massDensity="0.00000155" nbBeams="30" nbEdgesCollis="30" nbEdgesVisu="196" length="980.0"/>
+        <RodSpireSection name="SpireSection" youngModulus="20000" radius="0.9" massDensity="0.00000155" nbBeams="5" nbEdgesCollis="5" nbEdgesVisu="4" length="20.0" spireDiameter="25" spireHeight="0.0"/>
         
         <WireRestShape template="Rigid3d" name="BeamRestShape" printLog="1" wireMaterials="@StraightSection @SpireSection"/>
         <EdgeSetTopologyContainer name="meshLinesBeam"/>

--- a/examples/SingleBeamDeployment.scn
+++ b/examples/SingleBeamDeployment.scn
@@ -36,7 +36,7 @@
         <WireBeamInterpolation name="BeamInterpolation" WireRestShape="@../EdgeTopology/BeamRestShape" />
         <AdaptiveBeamForceFieldAndMass name="BeamForceField" interpolation="@BeamInterpolation"/>
         <InterventionalRadiologyController name="DeployController" template="Rigid3d" instruments="BeamInterpolation"
-                                    startingPos="0 0 0 0 0 0 1" xtip="0 0 0" printLog="1" 
+                                    topology="@MeshLines" startingPos="0 0 0 0 0 0 1" xtip="0 0 0" printLog="1" 
                                     rotationInstrument="0 0 0" step="0.5" speed="0.5" 
                                     listening="1" controlledInstrument="0"/>
         <FixedProjectiveConstraint name="FixedConstraint" indices="0" />

--- a/examples/SingleBeamDeploymentCollision.scn
+++ b/examples/SingleBeamDeploymentCollision.scn
@@ -32,8 +32,8 @@
 
 
     <Node name="EdgeTopology">
-        <RodStraightSection name="StraightSection" youngModulus="20000" radius="0.9" massDensity="0.00000155" poissonRatio="0.3" nbEdgesCollis="50" nbEdgesVisu="200" length="980.0"/>
-        <RodSpireSection name="SpireSection" youngModulus="20000" radius="0.9" massDensity="0.00000155" poissonRatio="0.3" nbEdgesCollis="10" nbEdgesVisu="200" length="20.0" spireDiameter="25" spireHeight="0.0"/>        
+        <RodStraightSection name="StraightSection" youngModulus="20000" radius="0.9" massDensity="0.00000155" poissonRatio="0.3" nbBeams="50" nbEdgesCollis="50" nbEdgesVisu="200" length="980.0"/>
+        <RodSpireSection name="SpireSection" youngModulus="20000" radius="0.9" massDensity="0.00000155" poissonRatio="0.3" nbBeams="10" nbEdgesCollis="10" nbEdgesVisu="200" length="20.0" spireDiameter="25" spireHeight="0.0"/>        
         
         <WireRestShape template="Rigid3d" name="BeamRestShape" wireMaterials="@StraightSection @SpireSection"/>
     
@@ -46,7 +46,7 @@
     <Node name="BeamModel">
         <EulerImplicitSolver rayleighStiffness="0.2" rayleighMass="0.1" printLog="false" />
         <BTDLinearSolver verbose="0"/>
-        <RegularGridTopology name="MeshLines" nx="60" ny="1" nz="1"
+        <RegularGridTopology name="MeshLines" nx="61" ny="1" nz="1"
                                     xmax="0.0" xmin="0.0" ymin="0" ymax="0" zmax="0" zmin="0"
                                     p0="0 0 0" drawEdges="1"/>
         <MechanicalObject template="Rigid3d" name="DOFs Container" ry="-90" /> 

--- a/examples/SingleBeamDeploymentCollision.scn
+++ b/examples/SingleBeamDeploymentCollision.scn
@@ -46,7 +46,7 @@
     <Node name="BeamModel">
         <EulerImplicitSolver rayleighStiffness="0.2" rayleighMass="0.1" printLog="false" />
         <BTDLinearSolver verbose="0"/>
-        <RegularGridTopology name="MeshLines" nx="61" ny="1" nz="1"
+        <RegularGridTopology name="MeshLines" nx="60" ny="1" nz="1"
                                     xmax="0.0" xmin="0.0" ymin="0" ymax="0" zmax="0" zmin="0"
                                     p0="0 0 0" drawEdges="1"/>
         <MechanicalObject template="Rigid3d" name="DOFs Container" ry="-90" /> 

--- a/examples/SingleBeamDeploymentCollision.scn
+++ b/examples/SingleBeamDeploymentCollision.scn
@@ -54,7 +54,7 @@
         <WireBeamInterpolation name="BeamInterpolation" WireRestShape="@../EdgeTopology/BeamRestShape"/>
         <AdaptiveBeamForceFieldAndMass name="BeamForceField" interpolation="@BeamInterpolation"/>
         <InterventionalRadiologyController name="DeployController" template="Rigid3d" instruments="BeamInterpolation"
-                                    startingPos="0 0 0 0 0 0 1" xtip="0 0 0" printLog="1" 
+                                    topology="@MeshLines" startingPos="0 0 0 0 0 0 1" xtip="0 0 0" printLog="1" 
                                     rotationInstrument="0 0 0" step="5" speed="5" 
                                     listening="1" controlledInstrument="0"/>
         <LinearSolverConstraintCorrection wire_optimization="true" printLog="0" />

--- a/examples/Tool_from_loader.scn
+++ b/examples/Tool_from_loader.scn
@@ -25,8 +25,8 @@
     <Node name="GuideCatheter">
         <MeshOBJLoader name="loader" filename="mesh/key_tip.obj" />
         
-        <RodStraightSection name="StraightSection" youngModulus="1000000" poissonRatio="0.3" radius="0.05" massDensity="0.1" nbEdgesCollis="30" nbEdgesVisu="200" length="980.0"/>
-        <RodMeshSection name="MeshTipSection" loader="@loader" nbEdgesCollis="300" nbEdgesVisu="300"  radius="0.05" massDensity="0.1"  youngModulus="1000000" poissonRatio="0.3"/>
+        <RodStraightSection name="StraightSection" youngModulus="1000000" poissonRatio="0.3" massDensity="0.00000155" radius="0.05" nbEdgesCollis="30" nbEdgesVisu="200" length="980.0"/>
+        <RodMeshSection name="MeshTipSection" loader="@loader" youngModulus="1000000" poissonRatio="0.3" massDensity="0.00000155" radius="0.05" nbEdgesCollis="300" nbEdgesVisu="300" />
         
         <WireRestShape template="Rigid3d" name="GC_RestShape" printLog="false" wireMaterials="@StraightSection @MeshTipSection" />
 

--- a/examples/Tool_from_loader.scn
+++ b/examples/Tool_from_loader.scn
@@ -25,8 +25,8 @@
     <Node name="GuideCatheter">
         <MeshOBJLoader name="loader" filename="mesh/key_tip.obj" />
         
-        <RodStraightSection name="StraightSection" youngModulus="1000000" poissonRatio="0.3" massDensity="0.00000155" radius="0.05" nbEdgesCollis="30" nbEdgesVisu="200" length="980.0"/>
-        <RodMeshSection name="MeshTipSection" loader="@loader" youngModulus="1000000" poissonRatio="0.3" massDensity="0.00000155" radius="0.05" nbEdgesCollis="300" nbEdgesVisu="300" />
+        <RodStraightSection name="StraightSection" youngModulus="1000000" poissonRatio="0.3" massDensity="0.00000155" radius="0.05" nbBeams="30" nbEdgesCollis="30" nbEdgesVisu="200" length="980.0"/>
+        <RodMeshSection name="MeshTipSection" loader="@loader" youngModulus="1000000" poissonRatio="0.3" massDensity="0.00000155" radius="0.05" nbBeams="300" nbEdgesCollis="300" nbEdgesVisu="300" />
         
         <WireRestShape template="Rigid3d" name="GC_RestShape" printLog="false" wireMaterials="@StraightSection @MeshTipSection" />
 
@@ -39,7 +39,7 @@
     <Node name="Instrument">
         <EulerImplicitSolver rayleighStiffness="0.2" rayleighMass="0.1" />
         <BTDLinearSolver />
-        <RegularGridTopology name="MeshLines" nx="330" ny="1" nz="1"
+        <RegularGridTopology name="MeshLines" nx="331" ny="1" nz="1"
             xmax="0.0" xmin="0.0" ymin="0" ymax="0" zmax="0" zmin="0"
             p0="0 0 0" drawEdges="0"/>
                                 

--- a/examples/python3/SingleBeamDeployment.py
+++ b/examples/python3/SingleBeamDeployment.py
@@ -12,7 +12,7 @@ def createScene(rootNode):
     topoLines = rootNode.addChild('EdgeTopology')
     topoLines.addObject('RodStraightSection', name='StraightSection', 
                                  length=980.0, radius=0.9, 
-                                 nbEdgesCollis=30, nbEdgesVisu=196, 
+                                 nbBeams=30, nbEdgesCollis=30, nbEdgesVisu=196, 
                                  youngModulus=20000, massDensity=0.00000155)
 
     topoLines.addObject('RodSpireSection', name='SpireSection', 
@@ -34,7 +34,7 @@ def createScene(rootNode):
     BeamMechanics.addObject('EulerImplicitSolver', rayleighStiffness=0.2, printLog=False, rayleighMass=0.1)
     BeamMechanics.addObject('BTDLinearSolver', verification=False, subpartSolve=False, verbose=False)
     BeamMechanics.addObject('RegularGridTopology', name='MeshLines', drawEdges=True, 
-                                    nx=60, ny=1, nz=1,
+                                    nx=61, ny=1, nz=1,
                                     xmax=0.0, xmin=0.0, ymin=0, ymax=0, zmax=0, zmin=0,
                                     p0=[0,0,0])
     BeamMechanics.addObject('MechanicalObject', showIndices=False, name='DOFs Container', template='Rigid3d', ry=-90)

--- a/examples/python3/SingleBeamDeployment.py
+++ b/examples/python3/SingleBeamDeployment.py
@@ -17,7 +17,7 @@ def createScene(rootNode):
 
     topoLines.addObject('RodSpireSection', name='SpireSection', 
                                  length=20.0, radius=0.9, 
-                                 nbEdgesCollis=5, nbEdgesVisu=4,
+                                 nbBeams=5, nbEdgesCollis=5, nbEdgesVisu=4,
                                  spireDiameter=25, spireHeight=0,
                                  youngModulus=20000, massDensity=0.00000155)
     topoLines.addObject('WireRestShape', name='BeamRestShape', template="Rigid3d",

--- a/examples/python3/SingleBeamDeployment.py
+++ b/examples/python3/SingleBeamDeployment.py
@@ -13,13 +13,13 @@ def createScene(rootNode):
     topoLines.addObject('RodStraightSection', name='StraightSection', 
                                  length=980.0, radius=0.9, 
                                  nbEdgesCollis=30, nbEdgesVisu=196, 
-                                 youngModulus=20000)
+                                 youngModulus=20000, massDensity=0.00000155)
 
     topoLines.addObject('RodSpireSection', name='SpireSection', 
                                  length=20.0, radius=0.9, 
                                  nbEdgesCollis=5, nbEdgesVisu=4,
                                  spireDiameter=25, spireHeight=0,
-                                 youngModulus=20000)
+                                 youngModulus=20000, massDensity=0.00000155)
     topoLines.addObject('WireRestShape', name='BeamRestShape', template="Rigid3d",
                                  wireMaterials="@StraightSection @SpireSection")
                                  

--- a/examples/python3/SingleBeamDeployment.py
+++ b/examples/python3/SingleBeamDeployment.py
@@ -41,7 +41,7 @@ def createScene(rootNode):
     BeamMechanics.addObject('WireBeamInterpolation', name='BeamInterpolation', WireRestShape='@../EdgeTopology/BeamRestShape', printLog=False)
     BeamMechanics.addObject('AdaptiveBeamForceFieldAndMass', name='BeamForceField', massDensity=0.00000155, interpolation='@BeamInterpolation')
     BeamMechanics.addObject('InterventionalRadiologyController', name='DeployController', template='Rigid3d', instruments='BeamInterpolation', 
-                                    startingPos=[0, 0, 0, 0, 0, 0, 1], xtip=[0, 0, 0], printLog=True, 
+                                    topology="@MeshLines", startingPos=[0, 0, 0, 0, 0, 0, 1], xtip=[0, 0, 0], printLog=True, 
                                     rotationInstrument=[0, 0, 0], step=0.5, speed=0.5, 
                                     listening=True, controlledInstrument=0)
     BeamMechanics.addObject('FixedProjectiveConstraint', indices=0, name='FixedConstraint')

--- a/examples/python3/SingleBeamDeploymentCollision.py
+++ b/examples/python3/SingleBeamDeploymentCollision.py
@@ -20,12 +20,12 @@ def createScene(rootNode):
     topoLines = rootNode.addChild('EdgeTopology')
     topoLines.addObject('RodStraightSection', name='StraightSection', 
                                  length=980.0, radius=0.9, 
-                                 nbEdgesCollis=50, nbEdgesVisu=200, 
+                                 nbBeams=50, nbEdgesCollis=50, nbEdgesVisu=200, 
                                  youngModulus=20000, massDensity=0.00000155, poissonRatio=0.3)
 
     topoLines.addObject('RodSpireSection', name='SpireSection', 
                                  length=20.0, radius=0.9, 
-                                 nbEdgesCollis=10, nbEdgesVisu=200,
+                                 nbBeams=10, nbEdgesCollis=10, nbEdgesVisu=200,
                                  spireDiameter=25, spireHeight=0,
                                  youngModulus=20000, massDensity=0.00000155, poissonRatio=0.3)
     topoLines.addObject('WireRestShape', name='BeamRestShape', template="Rigid3d",

--- a/examples/python3/SingleBeamDeploymentCollision.py
+++ b/examples/python3/SingleBeamDeploymentCollision.py
@@ -21,13 +21,13 @@ def createScene(rootNode):
     topoLines.addObject('RodStraightSection', name='StraightSection', 
                                  length=980.0, radius=0.9, 
                                  nbEdgesCollis=50, nbEdgesVisu=200, 
-                                 youngModulus=20000, massDensity=0.1, poissonRatio=0.3)
+                                 youngModulus=20000, massDensity=0.00000155, poissonRatio=0.3)
 
     topoLines.addObject('RodSpireSection', name='SpireSection', 
                                  length=20.0, radius=0.9, 
                                  nbEdgesCollis=10, nbEdgesVisu=200,
                                  spireDiameter=25, spireHeight=0,
-                                 youngModulus=20000, massDensity=0.1, poissonRatio=0.3)
+                                 youngModulus=20000, massDensity=0.00000155, poissonRatio=0.3)
     topoLines.addObject('WireRestShape', name='BeamRestShape', template="Rigid3d",
                                  wireMaterials="@StraightSection @SpireSection")
                                  
@@ -42,7 +42,7 @@ def createScene(rootNode):
     BeamMechanics.addObject('EulerImplicitSolver', rayleighStiffness=0.2, rayleighMass=0.1)
     BeamMechanics.addObject('BTDLinearSolver', verification=False, subpartSolve=False, verbose=False)
     BeamMechanics.addObject('RegularGridTopology', name='MeshLines', 
-                                    nx=60, ny=1, nz=1,
+                                    nx=61, ny=1, nz=1,
                                     xmax=0.0, xmin=0.0, ymin=0, ymax=0, zmax=0, zmin=0,
                                     p0=[0,0,0])
     BeamMechanics.addObject('MechanicalObject', showIndices=False, name='DOFs', template='Rigid3d', ry=-90)

--- a/examples/python3/SingleBeamDeploymentCollision.py
+++ b/examples/python3/SingleBeamDeploymentCollision.py
@@ -49,7 +49,7 @@ def createScene(rootNode):
     BeamMechanics.addObject('WireBeamInterpolation', name='BeamInterpolation', WireRestShape='@../EdgeTopology/BeamRestShape', printLog=False)
     BeamMechanics.addObject('AdaptiveBeamForceFieldAndMass', name='BeamForceField', massDensity=0.00000155, interpolation='@BeamInterpolation')
     BeamMechanics.addObject('InterventionalRadiologyController', name='DeployController', template='Rigid3d', instruments='BeamInterpolation', 
-                                    startingPos=[0, 0, 0, 0, 0, 0, 1], xtip=[0, 0, 0], printLog=True, 
+                                    topology="@MeshLines", startingPos=[0, 0, 0, 0, 0, 0, 1], xtip=[0, 0, 0], printLog=True, 
                                     rotationInstrument=[0, 0, 0], step=5., speed=5., 
                                     listening=True, controlledInstrument=0)
     BeamMechanics.addObject('LinearSolverConstraintCorrection', wire_optimization='true', printLog=False)


### PR DESCRIPTION
Note that there are warnings about Mass in the same node, because there are as many AdaptiveFFandMass as there are tools.

```
 Warning:  [Node(InstrumentCombined)] Trying to add a BaseMass ('unnamed' [AdaptiveBeamForceFieldAndMass] 0x55e365ac6680) into the Node '/InstrumentCombined', whereas it already contains one ('CatheterForceField' [AdaptiveBeamForceFieldAndMass] 0x55e36579c810). Only one BaseMass is permitted in a Node. The previous BaseMass is replaced and the behavior is undefined.
Warning:  [Node(InstrumentCombined)] Trying to add a BaseMass ('unnamed' [AdaptiveBeamForceFieldAndMass] 0x55e36593ff40) into the Node '/InstrumentCombined', whereas it already contains one ('GuideForceField' [AdaptiveBeamForceFieldAndMass] 0x55e365ac6680). Only one BaseMass is permitted in a Node. The previous BaseMass is replaced and the behavior is undefined.
```

I dont know how to fix it 🤔