### PR TITLE
MultiAdaptiveBeamMapping: Add the SubMapping(s) in the slave list

### DIFF
--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.inl
@@ -284,6 +284,9 @@ void MultiAdaptiveBeamMapping< TIn, TOut>::init()
         newMapping->d_parallelMapping.setParent(&d_parallelMapping);
         newMapping->d_parallelMapping.update();
         m_subMappingList.push_back(newMapping);
+        
+        // add in the list of slaves, it is useful to see the sub-mappings in the GUI
+        this->addSlave(newMapping);
     }
 
 


### PR DESCRIPTION
Mostly for UX convenience, it is useful to see the sub-mappings for debugging for example