### PR TITLE
[MultiAdaptiveBeamMapping] use Link instead of a string to set the controller

### DIFF
--- a/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.h
+++ b/src/BeamAdapter/component/mapping/MultiAdaptiveBeamMapping.h
@@ -87,8 +87,9 @@ public:
     typedef InterventionalRadiologyController<TIn> TInterventionalRadiologyController;
 
 public:
+    SingleLink<MultiAdaptiveBeamMapping<TIn, TOut>, TInterventionalRadiologyController, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_controller;
+    
     Data<bool> useCurvAbs;
-    Data< type::vector< std::string > > m_controlerPath;
     Data<bool> d_parallelMapping;           /*!< flag to enable parallel internal computation of apply/applyJ for the submapping(s) AdaptiveBeamMapping */
 
     MultiAdaptiveBeamMapping(core::State< In >* from, core::State< Out >* to, TInterventionalRadiologyController* _ircontroller);
@@ -105,10 +106,11 @@ public:
     void applyJT(const core::ConstraintParams *cparams /* PARAMS FIRST */, Data<InMatrixDeriv>& out, const Data<OutMatrixDeriv>& in) override;
 
 
-    virtual void init() override;
-    virtual void bwdInit() override;
+    void init() override;
+    void bwdInit() override;
 
-    virtual void handleEvent(sofa::core::objectmodel::Event *) override;
+    void handleEvent(sofa::core::objectmodel::Event *) override;
+    void parse(core::objectmodel::BaseObjectDescription* arg) override;
 
     void setBarycentricMapping();
 
@@ -142,7 +144,6 @@ protected:
     // for fromSeveralInterpolations option
     sofa::type::vector< WireBeamInterpolation<TIn>  *> m_instrumentList;
     sofa::type::vector<  typename AdaptiveBeamMapping<TIn, TOut>::SPtr > m_subMappingList;
-    TInterventionalRadiologyController* m_ircontroller;
     sofa::component::topology::container::dynamic::EdgeSetTopologyModifier* _edgeMod{nullptr};
     sofa::type::vector<InReal> _xPointList;     //=> for each mapped point provides the local position (curv. abs.)
     sofa::type::vector<int> _idm_instrumentList; //=> for each mapped point provides the interpolation (in m_instrumentList)


### PR DESCRIPTION
so many wrong stuff here...

- the controller was set with a string instead of a link (whereas all the other components use a link, it was weird)
- typos
- the comments were wrong

I renamed the attribute with the alias (which was always use) and set a compat layer.
The parse method will
- warn if using the old attribute name ("ircontroller")
- warn and change the string to be a link '@' if the value is not a string with a link format

So this PR will be breaking for compilation if one was using the deleted/renamed members but should not be breaking for runtime