### PR TITLE
[InterventionalRadiologyController] fix when giving 0 as index for fixFirstNodesWithUntil

### DIFF
--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -1121,14 +1121,20 @@ void InterventionalRadiologyController<DataTypes>::fillInstrumentCurvAbsTable(co
 template <class DataTypes>
 void InterventionalRadiologyController<DataTypes>::fixFirstNodesWithUntil(unsigned int firstSimulatedNode)
 {
+    l_fixedConstraint->clearConstraints();
+
+    if (firstSimulatedNode == 0)
+    {
+        d_indexFirstNode = 0;
+        return;
+    }
+
     WriteAccessor<Data<VecCoord> > xMstate = *getMechanicalState()->write(sofa::core::vec_id::write_access::position);
     WriteAccessor<Data<VecCoord> > xrestMstate = *getMechanicalState()->write(sofa::core::vec_id::write_access::restPosition);
     WriteAccessor<Data<VecDeriv> > vMstate = *getMechanicalState()->write(sofa::core::vec_id::write_access::velocity);
 
     // set the position to startingPos for all the nodes that are not simulated
     const auto& startPos = d_startingPos.getValue();
-    // and add a fixedConstraint
-    l_fixedConstraint->clearConstraints();
     for(unsigned int i=0; i<firstSimulatedNode-1 ; i++)
     {
         xMstate[i] = startPos;

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -1125,6 +1125,7 @@ void InterventionalRadiologyController<DataTypes>::fixFirstNodesWithUntil(unsign
 
     if (firstSimulatedNode == 0)
     {
+        msg_warning() << "An invalid value of firstSimulatedNode equal to 0 has been given to fixFirstNodesWithUntil() method.";
         d_indexFirstNode = 0;
         return;
     }


### PR DESCRIPTION
prevents the unsigned underflow of `for(unsigned int i=0; i<firstSimulatedNode-1 ; i++)` 
(not sure if the case arises but still)

if giving, then just dont constraint anything