### PR TITLE
[RodStraightSection] Fix rest shape double-offset for non-first sections

### DIFF
--- a/src/BeamAdapter/component/model/RodStraightSection.inl
+++ b/src/BeamAdapter/component/model/RodStraightSection.inl
@@ -53,7 +53,7 @@ bool RodStraightSection<DataTypes>::initSection()
 template <class DataTypes>
 void RodStraightSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start)
 {
-    global_H_local.set(type::Vec3(x_start + x_used, 0.0, 0.0), Quat());
+    global_H_local.set(type::Vec3(x_used, 0.0, 0.0), Quat());
 }
 
 


### PR DESCRIPTION
## Summary

Fixes #223.

`RodStraightSection::getRestTransformOnX` computed the rest position as `x_start + x_used`, but `x_used` is already the **global** curvilinear abscissa. This placed rest-shape nodes at `2 * x_start + local_offset` instead of `x_used` for any section that is not the first in the `wireMaterials` list.

**Example** (stiff section 420 mm + flex section 30 mm):

| | x_start | x_used | Old result | Correct |
|---|---|---|---|---|
| Section 0 | 0 | 210 | 210 ✓ | 210 |
| Section 1 | 420 | 430 | **850** ✗ | 430 |

The ~420 mm offset between rest shape and mechanical DOFs caused `AdaptiveBeamForceFieldAndMass` to generate huge elastic restoring forces every timestep, leading to simulation explosion on any disturbance (e.g. vessel-wall contact).

## Fix

```cpp
// Before
global_H_local.set(type::Vec3(x_start + x_used, 0.0, 0.0), Quat());

// After
global_H_local.set(type::Vec3(x_used, 0.0, 0.0), Quat());
```

This matches the pattern already used correctly by `RodSpireSection` and `RodMeshSection`. Zero effect on single-section wires (`x_start = 0`).