### PR TITLE
[WireRestShape] Fix initTopology accumulation for N≥3 sections

### DIFF
--- a/src/BeamAdapter/component/engine/WireRestShape.inl
+++ b/src/BeamAdapter/component/engine/WireRestShape.inl
@@ -173,8 +173,8 @@ bool WireRestShape<DataTypes>::initTopology()
             l_topology->addEdge(i, i + 1);
         }
 
-        prev_length = length;
-        prev_edges = nbrVisuEdges;
+        prev_length += length;
+        prev_edges += nbrVisuEdges;
         startPtId = 1; // Assume the last point of mat[n] == first point of mat[n+1]
     }
 

--- a/src/BeamAdapter/component/model/RodStraightSection.inl
+++ b/src/BeamAdapter/component/model/RodStraightSection.inl
@@ -53,7 +53,7 @@ bool RodStraightSection<DataTypes>::initSection()
 template <class DataTypes>
 void RodStraightSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start)
 {
-    global_H_local.set(type::Vec3(x_start + x_used, 0.0, 0.0), Quat());
+    global_H_local.set(type::Vec3(x_used, 0.0, 0.0), Quat());
 }
 
 


### PR DESCRIPTION
Fixes #225.

> **Note:** This PR is stacked on #224. The diff currently includes the `RodStraightSection` fix; once #224 merges this PR will reduce to a single commit.

## Problem

`WireRestShape::initTopology` uses two accumulator variables to track the running point-coordinate offset and edge index offset across sections. Both were updated via assignment instead of accumulation:

```cpp
prev_length = length;        // reset to local section length — should accumulate
prev_edges = nbrVisuEdges;   // reset to local edge count — should accumulate
```

For N≤2 sections the assignment and accumulation forms produce the same value after the first iteration, so those wires are unaffected. For N≥3 sections, section 2 onward receives corrupted point coordinates (overlapping prior sections) and wrong edge indices, producing a degenerate `EdgeSetTopologyContainer`.

## Fix

```cpp
prev_length += length;
prev_edges += nbrVisuEdges;
```

Zero behavioural change for N≤2 wires.

## Testing

Manually verified: 3-section wire fails on `master`, initialises correctly with this patch applied (on top of #224).