### PR TITLE
Fix wires with 3+ sections: initTopology accumulation + chained-section rest frame

### DIFF
--- a/src/BeamAdapter/component/engine/WireRestShape.inl
+++ b/src/BeamAdapter/component/engine/WireRestShape.inl
@@ -173,8 +173,8 @@ bool WireRestShape<DataTypes>::initTopology()
             l_topology->addEdge(i, i + 1);
         }
 
-        prev_length = length;
-        prev_edges = nbrVisuEdges;
+        prev_length += length;
+        prev_edges += nbrVisuEdges;
         startPtId = 1; // Assume the last point of mat[n] == first point of mat[n+1]
     }
 

--- a/src/BeamAdapter/component/engine/WireRestShape.inl
+++ b/src/BeamAdapter/component/engine/WireRestShape.inl
@@ -315,12 +315,23 @@ void WireRestShape<DataTypes>::getRestTransformOnX(Transform &global_H_local, co
     }
    
     const type::vector<Real>& keyPts = d_keyPoints.getValue();
+    // Walk all sections preceding the one that owns x_used and accumulate their tip transforms.
+    // Each section composes its local rest geometry with this predecessor frame, so chained non-straight
+    // sections (Spire after Spire, Mesh after Spire, ...) stay tangent-continuous instead of being placed
+    // along the world X axis at keyPts[i].
+    Transform predecessor = Transform::identity();
     for (sofa::Size i = 1; i < keyPts.size(); ++i)
     {
         if (x_used <= keyPts[i])
         {
-            return l_sectionMaterials.get(i - 1)->getRestTransformOnX(global_H_local, x_used, keyPts[i - 1]);
+            return l_sectionMaterials.get(i - 1)->getRestTransformOnX(
+                global_H_local, x_used, keyPts[i - 1], predecessor);
         }
+
+        Transform tip;
+        l_sectionMaterials.get(i - 1)->getRestTransformOnX(
+            tip, keyPts[i], keyPts[i - 1], predecessor);
+        predecessor = tip;
     }
 
     msg_error() << " problem in getRestTransformOnX : x_curv " << x_used << " is not between keyPoints" << d_keyPoints.getValue();

--- a/src/BeamAdapter/component/model/BaseRodSectionMaterial.h
+++ b/src/BeamAdapter/component/model/BaseRodSectionMaterial.h
@@ -93,12 +93,18 @@ public:
     /// Returns the Young modulus, Poisson's and massDensity coefficient of this section
     void getMechanicalParameters(Real& youngModulus, Real& cPoisson, Real& massDensity) const;
 
-    /// This function is called to get the rest position of the beam depending on the current curved abscisse given in parameter 
-    virtual void getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start)
+    /// This function is called to get the rest position of the beam depending on the current curved abscisse given in parameter.
+    /// @param predecessor_H_sectionStart locates this section's starting frame wrt world. Pass Transform::identity()
+    /// for the first section. Subsequent sections receive the accumulated tip transform of all preceding sections so
+    /// each section composes its local rest geometry with the actual end-frame of the predecessor instead of assuming
+    /// the wire so far ran straight along world +X.
+    virtual void getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start,
+                                     const Transform& predecessor_H_sectionStart)
     {
         SOFA_UNUSED(global_H_local);
         SOFA_UNUSED(x_used);
         SOFA_UNUSED(x_start);
+        SOFA_UNUSED(predecessor_H_sectionStart);
     }
  
 protected:

--- a/src/BeamAdapter/component/model/RodMeshSection.h
+++ b/src/BeamAdapter/component/model/RodMeshSection.h
@@ -53,8 +53,11 @@ public:
     /// Default Constructor
     RodMeshSection();
 
-    /// Override method to get the rest position of the beam. In this implementation, it will interpolate along the loaded mesh geometry
-    void getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start) override;
+    /// Override method to get the rest position of the beam. The mesh-interpolated rest transform is expressed in the
+    /// section's local frame (origin at the section start, +X = predecessor tip tangent) and composed with
+    /// @p predecessor_H_sectionStart to obtain the world rest transform.
+    void getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start,
+                             const Transform& predecessor_H_sectionStart) override;
       
 protected:
     /// Internal method to init the section. Called by @sa BaseRodSectionMaterial::init() method

--- a/src/BeamAdapter/component/model/RodMeshSection.inl
+++ b/src/BeamAdapter/component/model/RodMeshSection.inl
@@ -62,7 +62,8 @@ bool RodMeshSection<DataTypes>::initSection()
 
 
 template <class DataTypes>
-void RodMeshSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start)
+void RodMeshSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start,
+                                                   const Transform& predecessor_H_sectionStart)
 {
     Real abs_curr = x_used - x_start;
     abs_curr = abs_curr /(this->d_length.getValue()) * m_absOfGeometry;
@@ -97,11 +98,10 @@ void RodMeshSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, c
         p.getOrientation() = slerp;
     }
 
-    type::Vec3 PosEndCurve = p.getCenter();
-    Quat ExtremityQuat = p.getOrientation();
-    type::Vec3 ExtremityPos = PosEndCurve + type::Vec3(x_start, 0, 0);
-
-    global_H_local.set(ExtremityPos, ExtremityQuat);
+    // p is expressed in the section-local frame (origin at section start, +X = predecessor tip tangent).
+    Transform sectionStart_H_local;
+    sectionStart_H_local.set(p.getCenter(), p.getOrientation());
+    global_H_local = predecessor_H_sectionStart * sectionStart_H_local;
 }
 
 

--- a/src/BeamAdapter/component/model/RodSpireSection.h
+++ b/src/BeamAdapter/component/model/RodSpireSection.h
@@ -50,8 +50,11 @@ public:
     /// Default Constructor
     RodSpireSection();
 
-    /// Override method to get the rest position of the beam. In this implementation, it will compute the current position given the spire parameters
-    void getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start) override;
+    /// Override method to get the rest position of the beam. The spire is computed in the section's local frame
+    /// (origin at the section start, +X aligned with the predecessor tip tangent) and composed with
+    /// @p predecessor_H_sectionStart to obtain the world rest transform.
+    void getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start,
+                             const Transform& predecessor_H_sectionStart) override;
 
 protected:
     /// Internal method to init the section. Called by @sa BaseRodSectionMaterial::init() method

--- a/src/BeamAdapter/component/model/RodSpireSection.inl
+++ b/src/BeamAdapter/component/model/RodSpireSection.inl
@@ -53,7 +53,8 @@ bool RodSpireSection<DataTypes>::initSection()
 
 
 template <class DataTypes>
-void RodSpireSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start)
+void RodSpireSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start,
+                                                    const Transform& predecessor_H_sectionStart)
 {
     Real projetedLength = d_spireDiameter.getValue() * M_PI;
     Real lengthSpire = sqrt(d_spireHeight.getValue() * d_spireHeight.getValue() + projetedLength * projetedLength);
@@ -73,12 +74,13 @@ void RodSpireSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, 
     Qtheta.axisToQuat(type::Vec3(0, 1, 0), theta);
     Quat newSpireQuat = Qtheta * Qphi;
 
-    // computation of the position
+    // computation of the position in the section-local frame (origin at section start, +X = predecessor tip tangent)
     Real radius = d_spireDiameter.getValue() / 2.0;
     type::Vec3 PosEndCurve(radius * sin(theta), numSpire * d_spireHeight.getValue(), radius * (cos(theta) - 1));
-    type::Vec3 SpirePos = PosEndCurve + type::Vec3(x_start, 0, 0);
 
-    global_H_local.set(SpirePos, newSpireQuat);    
+    Transform sectionStart_H_local;
+    sectionStart_H_local.set(PosEndCurve, newSpireQuat);
+    global_H_local = predecessor_H_sectionStart * sectionStart_H_local;
 }
 
 } // namespace beamadapter

--- a/src/BeamAdapter/component/model/RodStraightSection.h
+++ b/src/BeamAdapter/component/model/RodStraightSection.h
@@ -47,8 +47,11 @@ public:
     /// Default Constructor
     RodStraightSection();
 
-    /// Override method to get the rest position of the beam. In this implementation, it will basically returns Vec3(x_start + x_used, 0 0)
-    void getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start) override;
+    /// Override method to get the rest position of the beam. The local rest position along the section's own +X axis
+    /// is composed with @p predecessor_H_sectionStart so the section continues tangent to the predecessor's tip frame
+    /// rather than assuming a world-X anchored start.
+    void getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start,
+                             const Transform& predecessor_H_sectionStart) override;
 
 protected:
     /// Internal method to init the section. Called by @sa BaseRodSectionMaterial::init() method

--- a/src/BeamAdapter/component/model/RodStraightSection.inl
+++ b/src/BeamAdapter/component/model/RodStraightSection.inl
@@ -51,9 +51,12 @@ bool RodStraightSection<DataTypes>::initSection()
 
 
 template <class DataTypes>
-void RodStraightSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start)
+void RodStraightSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start,
+                                                       const Transform& predecessor_H_sectionStart)
 {
-    global_H_local.set(type::Vec3(x_used, 0.0, 0.0), Quat());
+    Transform sectionStart_H_local;
+    sectionStart_H_local.set(type::Vec3(x_used - x_start, 0.0, 0.0), Quat());
+    global_H_local = predecessor_H_sectionStart * sectionStart_H_local;
 }
 
 

--- a/src/BeamAdapter/component/model/RodStraightSection.inl
+++ b/src/BeamAdapter/component/model/RodStraightSection.inl
@@ -53,7 +53,7 @@ bool RodStraightSection<DataTypes>::initSection()
 template <class DataTypes>
 void RodStraightSection<DataTypes>::getRestTransformOnX(Transform& global_H_local, const Real x_used, const Real x_start)
 {
-    global_H_local.set(type::Vec3(x_start + x_used, 0.0, 0.0), Quat());
+    global_H_local.set(type::Vec3(x_used, 0.0, 0.0), Quat());
 }
 
 


### PR DESCRIPTION
Fixes #227 (combined issue covering both bugs).

Two related bugs make any wire with three or more sections (or two chained non-straight sections) unusable. Both are fixed here.

## Bug 1 — `WireRestShape::initTopology` accumulation

`prev_length = length` and `prev_edges = nbrVisuEdges` discard the cumulative offset/edge count after section 0. Only N=2 wires happen to produce identical output. From iteration 2 onward, points are placed at non-monotonic abscissas, edges become degenerate, and `WireBeamInterpolation` / `MultiAdaptiveBeamMapping` break.

Fix:
```cpp
prev_length += length;
prev_edges += nbrVisuEdges;
```

(Originally tackled in #226, closed when further testing exposed Bug 2.)

## Bug 2 — Rod section rest shape ignores predecessor section frame

`BaseRodSectionMaterial::getRestTransformOnX(global_H_local, x_used, x_start)` carries no predecessor-tip transform. `RodSpireSection` / `RodMeshSection` reconstruct world position with `+ Vec3(x_start, 0, 0)`, which is correct only when the wire so far ran straight along world +X. As soon as a non-straight section follows another non-straight section, the rest pose sits in empty space, `AdaptiveBeamForceFieldAndMass` injects unbalanced elastic forces, and the terminal section becomes "floppy".

Fix:
- Virtual signature gains `const Transform& predecessor_H_sectionStart`.
- `RodStraightSection` / `RodSpireSection` / `RodMeshSection` compute their local rest geometry in the section's own frame (origin at section start, +X = predecessor tip tangent) and compose with the predecessor transform instead of adding `Vec3(x_start, 0, 0)`.
- `WireRestShape::getRestTransformOnX` walks preceding sections, queries each tip at `keyPts[i]` with its accumulated predecessor, then dispatches to the owning section with the composed frame.

Backward-compatible:
- One-section wire: predecessor = identity, `x_start = 0` → unchanged.
- Straight + curved tip: straight tip = `(keyPts[1], 0, 0)` with identity → matches old hardcoded form.

## Files changed

- `src/BeamAdapter/component/engine/WireRestShape.inl`
- `src/BeamAdapter/component/model/BaseRodSectionMaterial.h`
- `src/BeamAdapter/component/model/RodStraightSection.{h,inl}`
- `src/BeamAdapter/component/model/RodSpireSection.{h,inl}`
- `src/BeamAdapter/component/model/RodMeshSection.{h,inl}`

## Test plan

Verified manually:

- [x] Existing `WireRestShape_test` (Straight + Spire) still passes — backward-compat case: predecessor stays identity for the straight, then `(95, 0, 0)` identity for the spire dispatch, matching the old `Vec3(x_start, 0, 0)` form.
- [x] 3-section straight wire (100 + 50 + 25): visual `EdgeSetTopologyContainer` has monotonic point coordinates and the expected total edge count, no overlap.
- [x] `Straight + Spire(+90°) + Spire(+90°)`: rest pose of the second spire continues tangent to the first spire's tip instead of being placed along world +X at `keyPts[2]`; tip no longer drifts under no input.
- [x] Build green: `cmake --build . --target BeamAdapter`.