### PR TITLE
[mapping] BeamProjectionDifferenceMultiMapping: cleaning initial value

### DIFF
--- a/src/BeamAdapter/component/mapping/BeamProjectionDifferenceMultiMapping.inl
+++ b/src/BeamAdapter/component/mapping/BeamProjectionDifferenceMultiMapping.inl
@@ -56,8 +56,8 @@ BeamProjectionDifferenceMultiMapping<TIn1, TIn2, TOut>::BeamProjectionDifference
     , d_draw(initData(&d_draw, "draw", "Draw projection points and directions"))
     , d_drawSize(initData(&d_drawSize, Real(3), "drawSize", ""))
     , d_projections(initData(&d_projections, "projections", "Computed projection points."))
-    , d_filter(initData(&d_filter, Real(1e-2), "filter", "When updating the projection at each time step, use this parameter to filter small changes: "
-                                                         "If the projection is on the same edge as the previous step, and the weight (in [0, 1]) is smaller than the value of 'filter', skip."))
+    , d_filter(initData(&d_filter, Real(0), "filter", "When updating the projection at each time step, use this parameter to filter small changes: "
+                                                      "If the projection is on the same edge as the previous step, and the weight (in [0, 1]) is smaller than the value of 'filter', skip."))
     , l_in2Topology(initLink("topologyInput2", "link to input2's topology container (beams to project on)"))
     , l_interpolation(initLink("interpolationInput2", "link to input2's interpolation component (BeamInterpolation)"))
     , m_fromModel1(NULL)


### PR DESCRIPTION
I introduced an option to filter the projection update in #212.
To avoid changing behavior, the default value should be `0`.