### PR TITLE
[InterventionalRadiologyController] Remove motionData-related code

### DIFF
--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.h
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.h
@@ -156,7 +156,6 @@ public:
     void totalLengthIsChanging(const type::vector<Real>& newNodeCurvAbs, type::vector<Real>& modifiedNodeCurvAbs, const type::vector< type::vector<int> >& newTable);
     void fixFirstNodesWithUntil(unsigned int first_simulated_Node);
     void activateBeamListForCollision( type::vector<Real> &curv_abs, type::vector< type::vector<int> > &id_instrument_table);
-    void loadMotionData(std::string filename);
 
     Data<int>            d_controlledInstrument;
     Data<type::vector<Real>>   d_xTip;
@@ -167,12 +166,11 @@ public:
     Data<Coord>          d_startingPos;
     Data<Real>           d_threshold;
     Data<type::vector<Real>>   d_rigidCurvAbs; // Pairs (start - end)
-    Data<std::string>    d_motionFilename;
     Data<unsigned int>   d_indexFirstNode; // First Node simulated
-    
-    
+
+
     bool m_useBeamActions = false;
-    bool m_FF, m_RW, m_sensored;
+    bool m_FF = false, m_RW = false;
 
     SingleLink<
         InterventionalRadiologyController, FixedProjectiveConstraint<DataTypes>,
@@ -183,8 +181,6 @@ public:
     
     DeprecatedAndRemoved m_fixedConstraint;
 
-    type::vector<Vec3d>                   m_sensorMotionData;
-    unsigned int                    m_currentSensorData;
     type::vector<Real>                    m_nodeCurvAbs;
     type::vector< type::vector<int> >           m_idInstrumentCurvAbsTable;
 };

--- a/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
+++ b/src/BeamAdapter/component/controller/InterventionalRadiologyController.inl
@@ -38,7 +38,6 @@
 #include <sofa/component/topology/container/dynamic/EdgeSetGeometryAlgorithms.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/helper/AdvancedTimer.h>
-#include <sofa/helper/system/FileRepository.h>
 #include <sofa/type/vector_algorithm.h>
 
 
@@ -68,12 +67,10 @@ InterventionalRadiologyController<DataTypes>::InterventionalRadiologyController(
 , d_startingPos(initData(&d_startingPos,Coord(),"startingPos","starting pos for inserting the instrument"))
 , d_threshold(initData(&d_threshold, (Real)0.01, "threshold", "threshold for controller precision which is homogeneous to the unit of length used in the simulation"))
 , d_rigidCurvAbs(initData(&d_rigidCurvAbs, "rigidCurvAbs", "pairs of curv abs for beams we want to rigidify"))
-, d_motionFilename(initData(&d_motionFilename, "motionFilename", "text file that includes tracked motion from optical sensor"))
 , d_indexFirstNode(initData(&d_indexFirstNode, (unsigned int) 0, "indexFirstNode", "first node (should be fixed with restshape)"))
 , l_fixedConstraint(initLink("fixedConstraint", "Path to the FixedProjectiveConstraint"))
 , l_mechanicalTopology(initLink("topology", "Path to the mechanical topology"))
 {
-    m_sensored =false;
 }
 
 
@@ -137,13 +134,7 @@ void InterventionalRadiologyController<DataTypes>::init()
      {
          m_FF=true;
          m_RW=false;
-         m_sensored = false;
      }
-    if (!d_motionFilename.getValue().empty())
-    {
-        m_FF = true; m_sensored = true; m_currentSensorData = 0;
-        loadMotionData(d_motionFilename.getValue());
-    }
 
     auto checkData = [&](auto& data)
     {
@@ -296,31 +287,6 @@ void InterventionalRadiologyController<DataTypes>::init()
     sofa::core::objectmodel::BaseComponent::d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
-template<class DataTypes>
-void InterventionalRadiologyController<DataTypes>::loadMotionData(std::string filename)
-{
-    if (!helper::system::DataRepository.findFile(filename))
-    {
-        msg_error() << "File " << filename << " not found.";
-        return;
-    }
-    std::ifstream file(filename.c_str());
-
-    std::string line;
-    Vec3 result;
-    while( std::getline(file,line) )
-    {
-        if (line.empty())
-            continue;
-        std::istringstream values(line);
-        values >> result[0] >> result[1] >> result[2];
-        result[0] /= 1000;
-        m_sensorMotionData.push_back(result);
-    }
-
-    file.close();
-}
-
 /*!
  * \todo fix the mouse event with better controls
  */
@@ -413,26 +379,7 @@ void InterventionalRadiologyController<DataTypes>::onBeginAnimationStep(const do
         }
         if (m_FF)
         {
-            if (!m_sensored)
-                xInstrTip[id] += d_speed.getValue() * context->getDt();
-        else
-            {
-                unsigned int newSensorData = m_currentSensorData + 1;
-
-                while( m_sensorMotionData[newSensorData][0] < context->getTime() )
-                {
-                    m_currentSensorData = newSensorData;
-                    newSensorData++;
-                }
-                if(newSensorData >= m_sensorMotionData.size())
-                {
-                    xInstrTip[id] = 0;
-                }
-                else
-                {
-                    xInstrTip[id] += m_sensorMotionData[m_currentSensorData][1];
-                }
-            }
+            xInstrTip[id] += d_speed.getValue() * context->getDt();
         }
         if (m_RW)
         {


### PR DESCRIPTION
- superseded by BeamAdapterActionController.
- no doc on the format of the motion data file
- no example

Bonus point: fix UB for initialized m_FF and m_RW (accessed in onBeginAnimationStep)